### PR TITLE
custom dispatchers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ As an example consider this function that orthogonalizes a matrix using the modi
             rjj = do('linalg.norm', q, 2)
             Q.append(q / rjj)
 
-        return do('stack', Q, axis=0, like=X)
+        return do('stack', Q, axis=0)
 
 Which is now compatible with **all** of the above mentioned libraries! (N.B. this particular example is also probably slow). If you don't like the explicit ``do`` syntax, then you can import the fake ``numpy`` object as a **drop-in replacement** instead:
 

--- a/autoray/autoray.py
+++ b/autoray/autoray.py
@@ -20,7 +20,7 @@ limitations under the License.
 import importlib
 import functools
 import itertools
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import numpy as _numpy
 
@@ -75,7 +75,10 @@ def do(fn, *args, like=None, **kwargs):
         <tf.Tensor: id=91, shape=(3, 3), dtype=float32>
     """
     if like is None:
-        backend = infer_backend(args[0])
+        dispatch_arg = _DISPATCHERS.get(fn, default_dispatcher)(
+            *args, **kwargs
+        )
+        backend = infer_backend(dispatch_arg)
     elif isinstance(like, str):
         backend = like
     else:
@@ -87,9 +90,9 @@ def do(fn, *args, like=None, **kwargs):
 @functools.lru_cache(128)
 def _infer_class_backend_cached(T):
     if issubclass(T, _numpy.ndarray):
-        return 'numpy'
+        return "numpy"
 
-    lib = T.__module__.split('.')[0]
+    lib = T.__module__.split(".")[0]
 
     # check if lib should mapped entirely to another lib
     backend = _BACKEND_ALIASES.get(lib, lib)
@@ -134,15 +137,15 @@ def get_lib_fn(backend, fn):
 
             # if explicit submodule alias given, don't use prepended location
             #     for example, ('torch', 'linalg.svd') -> torch.svd
-            only_fn = fn.split('.')[-1]
+            only_fn = fn.split(".")[-1]
 
         except KeyError:
             full_location = module
 
             # move any prepended location into the full module path
             #     e.g. 'fn=linalg.eigh' -> ['linalg', 'eigh']
-            split_fn = fn.split('.')
-            full_location = '.'.join([full_location] + split_fn[:-1])
+            split_fn = fn.split(".")
+            full_location = ".".join([full_location] + split_fn[:-1])
             only_fn = split_fn[-1]
 
         # cached lookup of custom name function might take
@@ -154,7 +157,7 @@ def get_lib_fn(backend, fn):
             lib = importlib.import_module(full_location)
         except ImportError:
             # sometimes libraries hack an attribute to look like submodule
-            mod, submod = full_location.split('.')
+            mod, submod = full_location.split(".")
             lib = getattr(importlib.import_module(mod), submod)
 
         # check for a custom wrapper but default to identity
@@ -168,51 +171,45 @@ def get_lib_fn(backend, fn):
 
 # ---------------------- special top level functions ------------------------ #
 
+
 def conj(x):
-    """Array conjugate.
-    """
-    return do('conj', x)
+    """Array conjugate."""
+    return do("conj", x)
 
 
 def transpose(x, *args):
-    """Array transpose.
-    """
-    return do('transpose', x, *args)
+    """Array transpose."""
+    return do("transpose", x, *args)
 
 
 def dag(x):
-    """Array Hermitian transpose.
-    """
+    """Array Hermitian transpose."""
     try:
         return x.H
     except AttributeError:
-        return do('conj', do('transpose', x))
+        return do("conj", do("transpose", x))
 
 
 def real(x):
-    """Array real part.
-    """
-    return do('real', x)
+    """Array real part."""
+    return do("real", x)
 
 
 def imag(x):
-    """Array imaginary part.
-    """
-    return do('imag', x)
+    """Array imaginary part."""
+    return do("imag", x)
 
 
 def reshape(x, shape):
-    """Array reshaped.
-    """
+    """Array reshaped."""
     try:
         return x.reshape(shape)
     except AttributeError:
-        return do('reshape', x, shape)
+        return do("reshape", x, shape)
 
 
 def to_backend_dtype(dtype_name, like):
-    """Turn string specifier ``dtype_name`` into dtype of backend ``like``.
-    """
+    """Turn string specifier ``dtype_name`` into dtype of backend ``like``."""
     if not isinstance(like, str):
         like = infer_backend(like)
 
@@ -223,45 +220,41 @@ def to_backend_dtype(dtype_name, like):
 
 
 def get_dtype_name(x):
-    """Find string specifier ``dtype_name`` of array ``x``.
-    """
+    """Find string specifier ``dtype_name`` of array ``x``."""
     try:
         return x.dtype.name
     except AttributeError:
         # let modules provide their own
-        return do('get_dtype_name', x)
+        return do("get_dtype_name", x)
 
 
 def astype(x, dtype_name, **kwargs):
-    """Cast array as type ``dtype_name`` - tries ``x.astype`` first.
-    """
+    """Cast array as type ``dtype_name`` - tries ``x.astype`` first."""
     dtype = to_backend_dtype(dtype_name, like=x)
     try:
         return x.astype(dtype, **kwargs)
     except AttributeError:
-        return do('astype', x, dtype, **kwargs)
+        return do("astype", x, dtype, **kwargs)
 
 
 def to_numpy(x):
-    """Get a numpy version of array ``x``.
-    """
-    return do('to_numpy', x)
+    """Get a numpy version of array ``x``."""
+    return do("to_numpy", x)
 
 
 # -------------------------- some common wrappers --------------------------- #
 
-def svd_not_full_matrices_wrapper(fn):
 
+def svd_not_full_matrices_wrapper(fn):
     @functools.wraps(fn)
     def default_not_full_matrices(*args, **kwargs):
-        kwargs.setdefault('full_matrices', False)
+        kwargs.setdefault("full_matrices", False)
         return fn(*args, **kwargs)
 
     return default_not_full_matrices
 
 
 def svd_sUV_to_UsVH_wrapper(fn):
-
     @functools.wraps(fn)
     def numpy_like(*args, **kwargs):
         s, U, V = fn(*args, **kwargs)
@@ -271,7 +264,6 @@ def svd_sUV_to_UsVH_wrapper(fn):
 
 
 def svd_UsV_to_UsVH_wrapper(fn):
-
     @functools.wraps(fn)
     def numpy_like(*args, **kwargs):
         U, s, V = fn(*args, **kwargs)
@@ -281,13 +273,12 @@ def svd_UsV_to_UsVH_wrapper(fn):
 
 
 def svd_manual_full_matrices_kwarg(fn):
-
     @functools.wraps(fn)
     def numpy_like(*args, full_matrices=False, **kwargs):
         U, s, VH = fn(*args, **kwargs)
 
         if not full_matrices:
-            U, VH = U[:, :s.size], VH[:s.size, :]
+            U, VH = U[:, : s.size], VH[: s.size, :]
 
         return U, s, VH
 
@@ -295,7 +286,6 @@ def svd_manual_full_matrices_kwarg(fn):
 
 
 def qr_allow_fat(fn):
-
     @functools.wraps(fn)
     def numpy_like(a, **kwargs):
         m, n = a.shape
@@ -306,7 +296,7 @@ def qr_allow_fat(fn):
 
         Q, R_sq = fn(a[:, :m])
         R_r = dag(Q) @ a[:, m:]
-        R = do('concatenate', (R_sq, R_r), axis=1, like=a)
+        R = do("concatenate", (R_sq, R_r), axis=1, like=a)
 
         return Q, R
 
@@ -314,13 +304,14 @@ def qr_allow_fat(fn):
 
 
 def tril_to_band_part(fn):
-
     @functools.wraps(fn)
     def numpy_like(x, k=0):
 
         if k < 0:
-            raise ValueError("'k' must be positive to recreate 'numpy.tril' "
-                             "behaviour with 'tensorflow.matrix_band_part'.")
+            raise ValueError(
+                "'k' must be positive to recreate 'numpy.tril' "
+                "behaviour with 'tensorflow.matrix_band_part'."
+            )
 
         return fn(x, -1, k)
 
@@ -328,13 +319,14 @@ def tril_to_band_part(fn):
 
 
 def triu_to_band_part(fn):
-
     @functools.wraps(fn)
     def numpy_like(x, k=0):
 
         if k > 0:
-            raise ValueError("'k' must be negative to recreate 'numpy.triu' "
-                             "behaviour with 'tensorflow.matrix_band_part'.")
+            raise ValueError(
+                "'k' must be negative to recreate 'numpy.triu' "
+                "behaviour with 'tensorflow.matrix_band_part'."
+            )
 
         return fn(x, -k, -1)
 
@@ -342,7 +334,6 @@ def triu_to_band_part(fn):
 
 
 def scale_random_uniform_manually(fn):
-
     @functools.wraps(fn)
     def numpy_like(low=0.0, high=1.0, size=None, **kwargs):
         if size is None:
@@ -359,7 +350,6 @@ def scale_random_uniform_manually(fn):
 
 
 def scale_random_normal_manually(fn):
-
     @functools.wraps(fn)
     def numpy_like(loc=0.0, scale=1.0, size=None, **kwargs):
         if size is None:
@@ -419,14 +409,61 @@ def complex_add_re_im(re, im):
     return re + 1j * im
 
 
+# ----------------------------- Custom dispatchers -------------------------- #
+
+
+def register_dispatch(fun, dispatcher):
+    _DISPATCHERS[fun] = dispatcher
+
+
+def default_dispatcher(*args, **kwargs):
+    return args[0]
+
+
+# lookup of custom dispatcher methods, for cases when backend cannot be inferred
+#     accurately from first argument.
+_DISPATCHERS = defaultdict(lambda: default_dispatcher)
+
+
+# Numpy array joining operations always take a sequence of arrays as input.
+#     The backend is inferred from the first element of this sequence. Numpy
+#     always assumes that the argument is iterbale, so calling args[0][0]
+#     should be safe.
+def join_array_dispatcher(*args, **kwargs):
+    # NOTE: To be super safe, we could do a try / except, or
+    #       hasattr(args[0], '__getitem__'). hasattr is then probably better,
+    #       since there would be multiple types of errors to catch
+    return args[0][0]
+
+
+# List of functions listed in numpy API as array joining operations
+register_dispatch("concatenate", join_array_dispatcher)
+register_dispatch("stack", join_array_dispatcher)
+register_dispatch("block", join_array_dispatcher)
+register_dispatch("vstack", join_array_dispatcher)
+register_dispatch("hstack", join_array_dispatcher)
+register_dispatch("dstack", join_array_dispatcher)
+register_dispatch("column_stack", join_array_dispatcher)
+register_dispatch("row_stack", join_array_dispatcher)
+
+
+# einsum takes string as first argument a string, but backend should
+#      be inferred from second argument.
+def einsum_dispatcher(*args, **kwargs):
+    if isinstance(args[0], str):
+        return args[1]
+    return args[0]
+
+
+register_dispatch("einsum", einsum_dispatcher)
+
 # --------------- object to act as drop-in replace for numpy ---------------- #
 
 _partial_functions = {}
 
 
 class NumpyMimic:
-    """A class to mimic the syntax of using `numpy` directly.
-    """
+    """A class to mimic the syntax of using `numpy` directly."""
 
     def __init__(self, submodule=None):
         self.submodule = submodule
@@ -434,13 +471,13 @@ class NumpyMimic:
     def __getattribute__(self, fn):
 
         # look out for certain submodules which are not functions
-        if fn == 'linalg':
+        if fn == "linalg":
             return numpy_linalg
-        if fn == 'random':
+        if fn == "random":
             return numpy_random
 
         # if this is the e.g. linalg mimic, preprend 'linalg.'
-        submod = object.__getattribute__(self, 'submodule')
+        submod = object.__getattribute__(self, "submodule")
         if submod is not None:
             fn = ".".join((submod, fn))
 
@@ -458,8 +495,8 @@ class NumpyMimic:
 
 
 numpy = NumpyMimic()
-numpy_linalg = NumpyMimic('linalg')
-numpy_random = NumpyMimic('random')
+numpy_linalg = NumpyMimic("linalg")
+numpy_random = NumpyMimic("random")
 
 
 # --------------------------------------------------------------------------- #
@@ -486,35 +523,36 @@ _CUSTOM_WRAPPERS = {}
 #     to directly set an implementation of a function for a specific backend
 _FUNCS = {}
 
-
 # ------------------------------ standard-lib ------------------------------- #
 
-_MODULE_ALIASES['decimal'] = 'math'
-_MODULE_ALIASES['builtins'] = 'numpy'
+_MODULE_ALIASES["decimal"] = "math"
+_MODULE_ALIASES["builtins"] = "numpy"
 
 
 # ---------------------------------- numpy ---------------------------------- #
 
+
 def numpy_to_numpy(x):
-    return do('array', x, like='numpy')
+    return do("array", x, like="numpy")
 
 
-_FUNCS['numpy', 'to_numpy'] = numpy_to_numpy
-_FUNCS['numpy', 'complex'] = complex_add_re_im
-_FUNCS['builtins', 'to_numpy'] = numpy_to_numpy
-_SUBMODULE_ALIASES['numpy', 'linalg.expm'] = 'scipy.linalg'
-_CUSTOM_WRAPPERS['numpy', 'linalg.svd'] = svd_not_full_matrices_wrapper
+_FUNCS["numpy", "to_numpy"] = numpy_to_numpy
+_FUNCS["numpy", "complex"] = complex_add_re_im
+_FUNCS["builtins", "to_numpy"] = numpy_to_numpy
+_SUBMODULE_ALIASES["numpy", "linalg.expm"] = "scipy.linalg"
+_CUSTOM_WRAPPERS["numpy", "linalg.svd"] = svd_not_full_matrices_wrapper
 
 
 # ---------------------------------- cupy ----------------------------------- #
+
 
 def cupy_to_numpy(x):  # pragma: no cover
     return x.get()
 
 
-_FUNCS['cupy', 'to_numpy'] = cupy_to_numpy
-_FUNCS['cupy', 'complex'] = complex_add_re_im
-_CUSTOM_WRAPPERS['cupy', 'linalg.svd'] = svd_not_full_matrices_wrapper
+_FUNCS["cupy", "to_numpy"] = cupy_to_numpy
+_FUNCS["cupy", "complex"] = complex_add_re_im
+_CUSTOM_WRAPPERS["cupy", "linalg.svd"] = svd_not_full_matrices_wrapper
 
 
 # ----------------------------------- jax ----------------------------------- #
@@ -525,15 +563,20 @@ _JAX_RANDOM_KEY = None
 
 def jax_random_seed(seed=None):
     from jax.random import PRNGKey
+
     global _JAX_RANDOM_KEY
     if seed is None:
         from random import SystemRandom
-        seed = SystemRandom().randint(-2**63, 2**63 - 1)  # inclusive high
+
+        seed = SystemRandom().randint(
+            -(2 ** 63), 2 ** 63 - 1
+        )  # inclusive high
     _JAX_RANDOM_KEY = PRNGKey(seed)
 
 
 def jax_random_get_key():
     from jax.random import split
+
     global _JAX_RANDOM_KEY
     if _JAX_RANDOM_KEY is None:
         jax_random_seed()
@@ -543,14 +586,17 @@ def jax_random_get_key():
 
 def jax_random_uniform(low=0.0, high=1.0, size=None, **kwargs):
     from jax.random import uniform
+
     if size is None:
         size = ()
-    return uniform(jax_random_get_key(), shape=size,
-                   minval=low, maxval=high, **kwargs)
+    return uniform(
+        jax_random_get_key(), shape=size, minval=low, maxval=high, **kwargs
+    )
 
 
 def jax_random_normal(loc=0.0, scale=1.0, size=None, **kwargs):
     from jax.random import normal
+
     if size is None:
         size = ()
     x = normal(jax_random_get_key(), shape=size, **kwargs)
@@ -565,54 +611,56 @@ def jax_to_numpy(x):
     return x.__array__()
 
 
-_BACKEND_ALIASES['jaxlib'] = 'jax'
-_MODULE_ALIASES['jax'] = 'jax.numpy'
-_SUBMODULE_ALIASES['jax', 'complex'] = 'jax.lax'
-_SUBMODULE_ALIASES['jax', 'linalg.expm'] = 'jax.scipy.linalg'
-_CUSTOM_WRAPPERS['jax', 'linalg.qr'] = qr_allow_fat
-_CUSTOM_WRAPPERS['jax', 'linalg.svd'] = svd_not_full_matrices_wrapper
-_FUNCS['jax', 'to_numpy'] = jax_to_numpy
-_FUNCS['jax', 'random.seed'] = jax_random_seed
-_FUNCS['jax', 'random.uniform'] = jax_random_uniform
-_FUNCS['jax', 'random.normal'] = jax_random_normal
+_BACKEND_ALIASES["jaxlib"] = "jax"
+_MODULE_ALIASES["jax"] = "jax.numpy"
+_SUBMODULE_ALIASES["jax", "complex"] = "jax.lax"
+_SUBMODULE_ALIASES["jax", "linalg.expm"] = "jax.scipy.linalg"
+_CUSTOM_WRAPPERS["jax", "linalg.qr"] = qr_allow_fat
+_CUSTOM_WRAPPERS["jax", "linalg.svd"] = svd_not_full_matrices_wrapper
+_FUNCS["jax", "to_numpy"] = jax_to_numpy
+_FUNCS["jax", "random.seed"] = jax_random_seed
+_FUNCS["jax", "random.uniform"] = jax_random_uniform
+_FUNCS["jax", "random.normal"] = jax_random_normal
 
 
 # -------------------------------- autograd --------------------------------- #
 
-_MODULE_ALIASES['autograd'] = 'autograd.numpy'
-_CUSTOM_WRAPPERS['autograd', 'linalg.svd'] = svd_not_full_matrices_wrapper
-_FUNCS['autograd', 'complex'] = complex_add_re_im
+_MODULE_ALIASES["autograd"] = "autograd.numpy"
+_CUSTOM_WRAPPERS["autograd", "linalg.svd"] = svd_not_full_matrices_wrapper
+_FUNCS["autograd", "complex"] = complex_add_re_im
 
 
 # ---------------------------------- dask ----------------------------------- #
+
 
 def dask_to_numpy(x):
     return x.compute()
 
 
-_FUNCS['dask', 'to_numpy'] = dask_to_numpy
-_FUNCS['dask', 'complex'] = complex_add_re_im
-_FUNC_ALIASES['dask', 'abs'] = 'absolute'
-_MODULE_ALIASES['dask'] = 'dask.array'
-_CUSTOM_WRAPPERS['dask', 'linalg.svd'] = svd_manual_full_matrices_kwarg
+_FUNCS["dask", "to_numpy"] = dask_to_numpy
+_FUNCS["dask", "complex"] = complex_add_re_im
+_FUNC_ALIASES["dask", "abs"] = "absolute"
+_MODULE_ALIASES["dask"] = "dask.array"
+_CUSTOM_WRAPPERS["dask", "linalg.svd"] = svd_manual_full_matrices_kwarg
 
 
 # ---------------------------------- mars ----------------------------------- #
+
 
 def mars_to_numpy(x):
     return x.to_numpy()
 
 
-_FUNCS['mars', 'to_numpy'] = mars_to_numpy
-_FUNCS['mars', 'complex'] = complex_add_re_im
-_MODULE_ALIASES['mars'] = 'mars.tensor'
+_FUNCS["mars", "to_numpy"] = mars_to_numpy
+_FUNCS["mars", "complex"] = complex_add_re_im
+_MODULE_ALIASES["mars"] = "mars.tensor"
 
 
 # ----------------------------------- ctf ----------------------------------- #
 
 
 def ctf_array(x):
-    return do('astensor', x, like='ctf')
+    return do("astensor", x, like="ctf")
 
 
 def ctf_to_numpy(x):
@@ -623,18 +671,19 @@ def ctf_get_dtype_name(x):
     return x.dtype.__name__
 
 
-_FUNCS['ctf', 'array'] = ctf_array
-_FUNCS['ctf', 'to_numpy'] = ctf_to_numpy
-_FUNCS['ctf', 'get_dtype_name'] = ctf_get_dtype_name
-_SUBMODULE_ALIASES['ctf', 'linalg.svd'] = 'ctf'
-_SUBMODULE_ALIASES['ctf', 'linalg.eigh'] = 'ctf'
-_SUBMODULE_ALIASES['ctf', 'linalg.qr'] = 'ctf'
+_FUNCS["ctf", "array"] = ctf_array
+_FUNCS["ctf", "to_numpy"] = ctf_to_numpy
+_FUNCS["ctf", "get_dtype_name"] = ctf_get_dtype_name
+_SUBMODULE_ALIASES["ctf", "linalg.svd"] = "ctf"
+_SUBMODULE_ALIASES["ctf", "linalg.eigh"] = "ctf"
+_SUBMODULE_ALIASES["ctf", "linalg.qr"] = "ctf"
 
 
 # ------------------------------- sparse------------------------------------- #
 
+
 def sparse_array(x):
-    return do('COO.from_numpy', x, like='sparse')
+    return do("COO.from_numpy", x, like="sparse")
 
 
 def sparse_to_numpy(x):
@@ -674,51 +723,66 @@ def sparse_count_nonzero(x):
 
 
 def sparse_random_uniform(low=0.0, high=1.0, size=None, **kwargs):
-
     def rvs(nnz):
-        return do('random.uniform', low, high, (nnz,), like='numpy')
+        return do("random.uniform", low, high, (nnz,), like="numpy")
 
-    return do('random', size, data_rvs=rvs, **kwargs, like='sparse')
+    return do("random", size, data_rvs=rvs, **kwargs, like="sparse")
 
 
 def sparse_random_normal(loc=0.0, scale=1.0, size=None, **kwargs):
-
     def rvs(nnz):
-        return do('random.normal', loc, scale, (nnz,), like='numpy')
+        return do("random.normal", loc, scale, (nnz,), like="numpy")
 
-    return do('random', size, data_rvs=rvs, **kwargs, like='sparse')
+    return do("random", size, data_rvs=rvs, **kwargs, like="sparse")
 
 
-_FUNCS['sparse', 'array'] = sparse_array
-_FUNCS['sparse', 'to_numpy'] = sparse_to_numpy
-_FUNCS['sparse', 'transpose'] = sparse_transpose
-_FUNCS['sparse', 'sum'] = sparse_sum
-_FUNCS['sparse', 'prod'] = sparse_prod
-_FUNCS['sparse', 'conj'] = sparse_conj
-_FUNCS['sparse', 'real'] = sparse_real
-_FUNCS['sparse', 'imag'] = sparse_imag
-_FUNCS['sparse', 'complex'] = sparse_complex
-_FUNCS['sparse', 'count_nonzero'] = sparse_count_nonzero
-_FUNCS['sparse', 'random.uniform'] = sparse_random_uniform
-_FUNCS['sparse', 'random.normal'] = sparse_random_normal
+_FUNCS["sparse", "array"] = sparse_array
+_FUNCS["sparse", "to_numpy"] = sparse_to_numpy
+_FUNCS["sparse", "transpose"] = sparse_transpose
+_FUNCS["sparse", "sum"] = sparse_sum
+_FUNCS["sparse", "prod"] = sparse_prod
+_FUNCS["sparse", "conj"] = sparse_conj
+_FUNCS["sparse", "real"] = sparse_real
+_FUNCS["sparse", "imag"] = sparse_imag
+_FUNCS["sparse", "complex"] = sparse_complex
+_FUNCS["sparse", "count_nonzero"] = sparse_count_nonzero
+_FUNCS["sparse", "random.uniform"] = sparse_random_uniform
+_FUNCS["sparse", "random.normal"] = sparse_random_normal
 
 # sparse uses numpys __array_func__ interface
-for f in ('log', 'log2', 'log10', 'exp', 'sqrt', 'sign',
-          'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
-          'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh'):
-    _SUBMODULE_ALIASES['sparse', f] = 'numpy'
+for f in (
+    "log",
+    "log2",
+    "log10",
+    "exp",
+    "sqrt",
+    "sign",
+    "sin",
+    "cos",
+    "tan",
+    "arcsin",
+    "arccos",
+    "arctan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "arcsinh",
+    "arccosh",
+    "arctanh",
+):
+    _SUBMODULE_ALIASES["sparse", f] = "numpy"
 
 
 # ------------------------------- tensorflow -------------------------------- #
+
 
 def tensorflow_to_numpy(x):
     return x.numpy()
 
 
 def tensorflow_pad_wrap(tf_pad):
-
-    def numpy_like(array, pad_width, mode='constant', constant_values=0):
-        if mode != 'constant':
+    def numpy_like(array, pad_width, mode="constant", constant_values=0):
+        if mode != "constant":
             raise NotImplementedError
 
         try:
@@ -727,63 +791,72 @@ def tensorflow_pad_wrap(tf_pad):
         except TypeError:
             pad_width = ((pad_width, pad_width),) * len(array.shape)
 
-        return tf_pad(array, pad_width, mode='CONSTANT',
-                      constant_values=constant_values)
+        return tf_pad(
+            array, pad_width, mode="CONSTANT", constant_values=constant_values
+        )
 
     return numpy_like
 
 
-_FUNCS['tensorflow', 'to_numpy'] = tensorflow_to_numpy
+_FUNCS["tensorflow", "to_numpy"] = tensorflow_to_numpy
 
-_SUBMODULE_ALIASES['tensorflow', 'log'] = 'tensorflow.math'
-_SUBMODULE_ALIASES['tensorflow', 'conj'] = 'tensorflow.math'
-_SUBMODULE_ALIASES['tensorflow', 'real'] = 'tensorflow.math'
-_SUBMODULE_ALIASES['tensorflow', 'imag'] = 'tensorflow.math'
-_SUBMODULE_ALIASES['tensorflow', 'power'] = 'tensorflow.math'
-_SUBMODULE_ALIASES['tensorflow', 'count_nonzero'] = 'tensorflow.math'
-_SUBMODULE_ALIASES['tensorflow', 'diag'] = 'tensorflow.linalg'
-_SUBMODULE_ALIASES['tensorflow', 'trace'] = 'tensorflow.linalg'
-_SUBMODULE_ALIASES['tensorflow', 'tril'] = 'tensorflow.linalg'
-_SUBMODULE_ALIASES['tensorflow', 'triu'] = 'tensorflow.linalg'
+_SUBMODULE_ALIASES["tensorflow", "log"] = "tensorflow.math"
+_SUBMODULE_ALIASES["tensorflow", "conj"] = "tensorflow.math"
+_SUBMODULE_ALIASES["tensorflow", "real"] = "tensorflow.math"
+_SUBMODULE_ALIASES["tensorflow", "imag"] = "tensorflow.math"
+_SUBMODULE_ALIASES["tensorflow", "power"] = "tensorflow.math"
+_SUBMODULE_ALIASES["tensorflow", "count_nonzero"] = "tensorflow.math"
+_SUBMODULE_ALIASES["tensorflow", "diag"] = "tensorflow.linalg"
+_SUBMODULE_ALIASES["tensorflow", "trace"] = "tensorflow.linalg"
+_SUBMODULE_ALIASES["tensorflow", "tril"] = "tensorflow.linalg"
+_SUBMODULE_ALIASES["tensorflow", "triu"] = "tensorflow.linalg"
 
-_FUNC_ALIASES['tensorflow', 'sum'] = 'reduce_sum'
-_FUNC_ALIASES['tensorflow', 'min'] = 'reduce_min'
-_FUNC_ALIASES['tensorflow', 'max'] = 'reduce_max'
-_FUNC_ALIASES['tensorflow', 'mean'] = 'reduce_mean'
-_FUNC_ALIASES['tensorflow', 'prod'] = 'reduce_prod'
-_FUNC_ALIASES['tensorflow', 'concatenate'] = 'concat'
-_FUNC_ALIASES['tensorflow', 'clip'] = 'clip_by_value'
-_FUNC_ALIASES['tensorflow', 'arange'] = 'range'
-_FUNC_ALIASES['tensorflow', 'tril'] = 'band_part'
-_FUNC_ALIASES['tensorflow', 'triu'] = 'band_part'
-_FUNC_ALIASES['tensorflow', 'diag'] = 'tensor_diag'
-_FUNC_ALIASES['tensorflow', 'array'] = 'convert_to_tensor'
-_FUNC_ALIASES['tensorflow', 'astype'] = 'cast'
-_FUNC_ALIASES['tensorflow', 'power'] = 'pow'
+_FUNC_ALIASES["tensorflow", "sum"] = "reduce_sum"
+_FUNC_ALIASES["tensorflow", "min"] = "reduce_min"
+_FUNC_ALIASES["tensorflow", "max"] = "reduce_max"
+_FUNC_ALIASES["tensorflow", "mean"] = "reduce_mean"
+_FUNC_ALIASES["tensorflow", "prod"] = "reduce_prod"
+_FUNC_ALIASES["tensorflow", "concatenate"] = "concat"
+_FUNC_ALIASES["tensorflow", "clip"] = "clip_by_value"
+_FUNC_ALIASES["tensorflow", "arange"] = "range"
+_FUNC_ALIASES["tensorflow", "tril"] = "band_part"
+_FUNC_ALIASES["tensorflow", "triu"] = "band_part"
+_FUNC_ALIASES["tensorflow", "diag"] = "tensor_diag"
+_FUNC_ALIASES["tensorflow", "array"] = "convert_to_tensor"
+_FUNC_ALIASES["tensorflow", "astype"] = "cast"
+_FUNC_ALIASES["tensorflow", "power"] = "pow"
+_FUNC_ALIASES["tensorflow", "take"] = "gather"
 
-_CUSTOM_WRAPPERS['tensorflow', 'linalg.svd'] = svd_sUV_to_UsVH_wrapper
-_CUSTOM_WRAPPERS['tensorflow', 'linalg.qr'] = qr_allow_fat
-_CUSTOM_WRAPPERS['tensorflow', 'tril'] = tril_to_band_part
-_CUSTOM_WRAPPERS['tensorflow', 'triu'] = triu_to_band_part
-_CUSTOM_WRAPPERS['tensorflow', 'pad'] = tensorflow_pad_wrap
-_CUSTOM_WRAPPERS['tensorflow', 'random.uniform'] = make_translator([
-    ('low', ('minval', 0.0)),
-    ('high', ('maxval', 1.0)),
-    ('size', ('shape', ())),
-])
-_CUSTOM_WRAPPERS['tensorflow', 'random.normal'] = make_translator([
-    ('loc', ('mean', 0.0)),
-    ('scale', ('stddev', 1.0)),
-    ('size', ('shape', ())),
-])
-_CUSTOM_WRAPPERS['tensorflow', 'clip'] = make_translator([
-    ('a', ('t', 0.0)),
-    ('a_min', ('clip_value_min',)),
-    ('a_max', ('clip_value_max',)),
-])
+_CUSTOM_WRAPPERS["tensorflow", "linalg.svd"] = svd_sUV_to_UsVH_wrapper
+_CUSTOM_WRAPPERS["tensorflow", "linalg.qr"] = qr_allow_fat
+_CUSTOM_WRAPPERS["tensorflow", "tril"] = tril_to_band_part
+_CUSTOM_WRAPPERS["tensorflow", "triu"] = triu_to_band_part
+_CUSTOM_WRAPPERS["tensorflow", "pad"] = tensorflow_pad_wrap
+_CUSTOM_WRAPPERS["tensorflow", "random.uniform"] = make_translator(
+    [
+        ("low", ("minval", 0.0)),
+        ("high", ("maxval", 1.0)),
+        ("size", ("shape", ())),
+    ]
+)
+_CUSTOM_WRAPPERS["tensorflow", "random.normal"] = make_translator(
+    [
+        ("loc", ("mean", 0.0)),
+        ("scale", ("stddev", 1.0)),
+        ("size", ("shape", ())),
+    ]
+)
+_CUSTOM_WRAPPERS["tensorflow", "clip"] = make_translator(
+    [
+        ("a", ("t", 0.0)),
+        ("a_min", ("clip_value_min",)),
+        ("a_max", ("clip_value_max",)),
+    ]
+)
 
 
 # ---------------------------------- torch ---------------------------------- #
+
 
 def torch_to_numpy(x):
     return x.detach().cpu().numpy()
@@ -796,7 +869,7 @@ def torch_transpose(x, axes=None):
 
 
 def torch_count_nonzero(x):
-    return do('sum', x != 0, like='torch')
+    return do("sum", x != 0, like="torch")
 
 
 def torch_astype(x, dtype):
@@ -805,7 +878,7 @@ def torch_astype(x, dtype):
 
 @functools.lru_cache(32)
 def _torch_get_dtype_name(dtype):
-    return str(dtype).split('.')[-1]
+    return str(dtype).split(".")[-1]
 
 
 def torch_get_dtype_name(x):
@@ -829,23 +902,23 @@ def torch_imag(x):
             return x.imag
     except AttributeError:
         pass
-    return do('zeros_like', x, like='torch')
+    return do("zeros_like", x, like="torch")
 
 
 def torch_linalg_solve(a, b):
-    return do('solve', b, a, like='torch')[0]
+    return do("solve", b, a, like="torch")[0]
 
 
 def torch_linalg_eigh(x):
-    return tuple(do('symeig', x, eigenvectors=True, like='torch'))
+    return tuple(do("symeig", x, eigenvectors=True, like="torch"))
 
 
 def torch_linalg_eigvalsh(x):
-    return do('symeig', x, eigenvectors=False, like='torch')[0]
+    return do("symeig", x, eigenvectors=False, like="torch")[0]
 
 
-def torch_pad(array, pad_width, mode='constant', constant_values=0):
-    if mode != 'constant':
+def torch_pad(array, pad_width, mode="constant", constant_values=0):
+    if mode != "constant":
         raise NotImplementedError
 
     try:
@@ -861,74 +934,102 @@ def torch_pad(array, pad_width, mode='constant', constant_values=0):
         # assume int
         pad = (pad_width,) * 2 * array.ndimension()
 
-    return do('nn.functional.pad', array, pad=pad,
-              mode=mode, value=constant_values, like='torch')
+    return do(
+        "nn.functional.pad",
+        array,
+        pad=pad,
+        mode=mode,
+        value=constant_values,
+        like="torch",
+    )
 
 
-_FUNCS['torch', 'pad'] = torch_pad
-_FUNCS['torch', 'real'] = torch_real
-_FUNCS['torch', 'imag'] = torch_imag
-_FUNCS['torch', 'astype'] = torch_astype
-_FUNCS['torch', 'to_numpy'] = torch_to_numpy
-_FUNCS['torch', 'complex'] = complex_add_re_im
-_FUNCS['torch', 'transpose'] = torch_transpose
-_FUNCS['torch', 'count_nonzero'] = torch_count_nonzero
-_FUNCS['torch', 'get_dtype_name'] = torch_get_dtype_name
-_FUNCS['torch', 'linalg.solve'] = torch_linalg_solve
-_FUNCS['torch', 'linalg.eigh'] = torch_linalg_eigh
-_FUNCS['torch', 'linalg.eigvalsh'] = torch_linalg_eigvalsh
+_FUNCS["torch", "pad"] = torch_pad
+_FUNCS["torch", "real"] = torch_real
+_FUNCS["torch", "imag"] = torch_imag
+_FUNCS["torch", "astype"] = torch_astype
+_FUNCS["torch", "to_numpy"] = torch_to_numpy
+_FUNCS["torch", "complex"] = complex_add_re_im
+_FUNCS["torch", "transpose"] = torch_transpose
+_FUNCS["torch", "count_nonzero"] = torch_count_nonzero
+_FUNCS["torch", "get_dtype_name"] = torch_get_dtype_name
+_FUNCS["torch", "linalg.solve"] = torch_linalg_solve
+_FUNCS["torch", "linalg.eigh"] = torch_linalg_eigh
+_FUNCS["torch", "linalg.eigvalsh"] = torch_linalg_eigvalsh
 
-_FUNC_ALIASES['torch', 'clip'] = 'clamp'
-_FUNC_ALIASES['torch', 'power'] = 'pow'
-_FUNC_ALIASES['torch', 'array'] = 'tensor'
-_FUNC_ALIASES['torch', 'concatenate'] = 'cat'
-_FUNC_ALIASES['torch', 'random.normal'] = 'randn'
-_FUNC_ALIASES['torch', 'random.uniform'] = 'rand'
-_FUNC_ALIASES['torch', 'linalg.expm'] = 'matrix_exp'
+_FUNC_ALIASES["torch", "clip"] = "clamp"
+_FUNC_ALIASES["torch", "power"] = "pow"
+_FUNC_ALIASES["torch", "array"] = "tensor"
+_FUNC_ALIASES["torch", "concatenate"] = "cat"
+_FUNC_ALIASES["torch", "random.normal"] = "randn"
+_FUNC_ALIASES["torch", "random.uniform"] = "rand"
+_FUNC_ALIASES["torch", "linalg.expm"] = "matrix_exp"
+_FUNC_ALIASES["torch", "take"] = "index_select"
 
-_SUBMODULE_ALIASES['torch', 'linalg.qr'] = 'torch'
-_SUBMODULE_ALIASES['torch', 'linalg.svd'] = 'torch'
-_SUBMODULE_ALIASES['torch', 'linalg.expm'] = 'torch'
-_SUBMODULE_ALIASES['torch', 'random.normal'] = 'torch'
-_SUBMODULE_ALIASES['torch', 'random.uniform'] = 'torch'
+_SUBMODULE_ALIASES["torch", "linalg.qr"] = "torch"
+_SUBMODULE_ALIASES["torch", "linalg.svd"] = "torch"
+_SUBMODULE_ALIASES["torch", "linalg.expm"] = "torch"
+_SUBMODULE_ALIASES["torch", "random.normal"] = "torch"
+_SUBMODULE_ALIASES["torch", "random.uniform"] = "torch"
 
-_CUSTOM_WRAPPERS['torch', 'linalg.svd'] = svd_UsV_to_UsVH_wrapper
-_CUSTOM_WRAPPERS['torch', 'linalg.qr'] = qr_allow_fat
-_CUSTOM_WRAPPERS['torch', 'random.normal'] = scale_random_normal_manually
-_CUSTOM_WRAPPERS['torch', 'random.uniform'] = scale_random_uniform_manually
-_CUSTOM_WRAPPERS['torch', 'stack'] = make_translator([
-    ('arrays', ('tensors',)),
-    ('axis', ('dim', 0)),
-])
-_CUSTOM_WRAPPERS['torch', 'concatenate'] = make_translator([
-    ('arrays', ('tensors',)),
-    ('axis', ('dim', 0))
-])
-_CUSTOM_WRAPPERS['torch', 'tril'] = make_translator([
-    ('m', ('input',)),
-    ('k', ('diagonal', 0)),
-])
-_CUSTOM_WRAPPERS['torch', 'triu'] = make_translator([
-    ('m', ('input',)),
-    ('k', ('diagonal', 0)),
-])
-_CUSTOM_WRAPPERS['torch', 'clip'] = make_translator([
-    ('a', ('input',)),
-    ('a_min', ('min',)),
-    ('a_max', ('max',)),
-])
-_CUSTOM_WRAPPERS['torch', 'ones'] = make_translator([
-    ('shape', ('size',)),
-])
-_CUSTOM_WRAPPERS['torch', 'zeros'] = make_translator([
-    ('shape', ('size',)),
-])
-_CUSTOM_WRAPPERS['torch', 'empty'] = make_translator([
-    ('shape', ('size',)),
-])
+_CUSTOM_WRAPPERS["torch", "linalg.svd"] = svd_UsV_to_UsVH_wrapper
+_CUSTOM_WRAPPERS["torch", "linalg.qr"] = qr_allow_fat
+_CUSTOM_WRAPPERS["torch", "random.normal"] = scale_random_normal_manually
+_CUSTOM_WRAPPERS["torch", "random.uniform"] = scale_random_uniform_manually
+_CUSTOM_WRAPPERS["torch", "stack"] = make_translator(
+    [
+        ("arrays", ("tensors",)),
+        ("axis", ("dim", 0)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "concatenate"] = make_translator(
+    [("arrays", ("tensors",)), ("axis", ("dim", 0))]
+)
+_CUSTOM_WRAPPERS["torch", "tril"] = make_translator(
+    [
+        ("m", ("input",)),
+        ("k", ("diagonal", 0)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "triu"] = make_translator(
+    [
+        ("m", ("input",)),
+        ("k", ("diagonal", 0)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "clip"] = make_translator(
+    [
+        ("a", ("input",)),
+        ("a_min", ("min",)),
+        ("a_max", ("max",)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "ones"] = make_translator(
+    [
+        ("shape", ("size",)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "zeros"] = make_translator(
+    [
+        ("shape", ("size",)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "empty"] = make_translator(
+    [
+        ("shape", ("size",)),
+    ]
+)
+_CUSTOM_WRAPPERS["torch", "take"] = make_translator(
+    [
+        ("a", ("input",)),
+        ("indices", ("index",)),
+        ("axis", ("dim",)),
+    ]
+)
 
 
 # --------------------------- register your own! ---------------------------- #
+
 
 def register_function(backend, name, fn, wrap=False):
     """Directly provide your own function.

--- a/tests/test_autoray.py
+++ b/tests/test_autoray.py
@@ -6,35 +6,37 @@ import autoray as ar
 
 
 # find backends to tests
-BACKENDS = ['numpy']
-for lib in ['cupy', 'dask', 'tensorflow', 'torch', 'mars', 'jax', 'sparse']:
+BACKENDS = ["numpy"]
+for lib in ["cupy", "dask", "tensorflow", "torch", "mars", "jax", "sparse"]:
     if importlib.util.find_spec(lib):
         BACKENDS.append(pytest.param(lib))
 
-        if lib == 'jax':
+        if lib == "jax":
             import os
             from jax.config import config
+
             config.update("jax_enable_x64", True)
-            os.environ['XLA_PYTHON_CLIENT_ALLOCATOR'] = 'platform'
+            os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 
     else:
-        BACKENDS.append(pytest.param(
-            lib,
-            marks=pytest.mark.skipif(True, reason=f"No {lib}.")
-        ))
+        BACKENDS.append(
+            pytest.param(
+                lib, marks=pytest.mark.skipif(True, reason=f"No {lib}.")
+            )
+        )
 
 
 JAX_RANDOM_KEY = None
 
 
-def gen_rand(shape, backend, dtype='float64'):
+def gen_rand(shape, backend, dtype="float64"):
 
-    if 'complex' in dtype:
+    if "complex" in dtype:
         re = gen_rand(shape, backend)
         im = gen_rand(shape, backend)
-        return ar.astype(ar.do('complex', re, im), dtype)
+        return ar.astype(ar.do("complex", re, im), dtype)
 
-    if backend == 'jax':
+    if backend == "jax":
         from jax import random as jrandom
 
         global JAX_RANDOM_KEY
@@ -45,38 +47,47 @@ def gen_rand(shape, backend, dtype='float64'):
 
         return jrandom.uniform(subkey, shape=shape, dtype=dtype)
 
-    elif backend == 'sparse':
-        x = ar.do('random.uniform', size=shape, like=backend,
-                  density=0.5, format='coo', fill_value=0)
+    elif backend == "sparse":
+        x = ar.do(
+            "random.uniform",
+            size=shape,
+            like=backend,
+            density=0.5,
+            format="coo",
+            fill_value=0,
+        )
 
     else:
-        x = ar.do('random.uniform', size=shape, like=backend)
+        x = ar.do("random.uniform", size=shape, like=backend)
 
     x = ar.astype(x, ar.to_backend_dtype(dtype, backend))
     assert ar.get_dtype_name(x) == dtype
     return x
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('fn', ['sqrt', 'exp', 'sum'])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("fn", ["sqrt", "exp", "sum"])
 def test_basic(backend, fn):
     x = gen_rand((2, 3, 4), backend)
     y = ar.do(fn, x)
-    if (backend == 'sparse') and (fn is 'sum'):
+    if (backend == "sparse") and (fn is "sum"):
         pytest.xfail("Sparse 'sum' outputs dense.")
     assert ar.infer_backend(x) == ar.infer_backend(y) == backend
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('fn,args', [
-    (ar.conj, []),
-    (ar.transpose, []),
-    (ar.real, []),
-    (ar.imag, []),
-    (ar.reshape, [(5, 3)]),
-])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "fn,args",
+    [
+        (ar.conj, []),
+        (ar.transpose, []),
+        (ar.real, []),
+        (ar.imag, []),
+        (ar.reshape, [(5, 3)]),
+    ],
+)
 def test_attribute_prefs(backend, fn, args):
-    if (backend is 'torch') and fn in (ar.real, ar.imag):
+    if (backend is "torch") and fn in (ar.real, ar.imag):
         pytest.xfail("Pytorch doesn't support complex numbers yet...")
 
     x = gen_rand((3, 5), backend)
@@ -91,27 +102,28 @@ def modified_gram_schmidt(X):
 
         q = X[j, :]
         for i in range(0, j):
-            rij = ar.do('tensordot', ar.do('conj', Q[i]), q, 1)
+            rij = ar.do("tensordot", ar.do("conj", Q[i]), q, 1)
             q = q - rij * Q[i]
 
-        rjj = ar.do('linalg.norm', q, 2)
+        rjj = ar.do("linalg.norm", q, 2)
         Q.append(q / rjj)
 
-    return ar.do('stack', Q, axis=0, like=X)
+    return ar.do("stack", Q, axis=0, like=X)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_mgs(backend):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("Sparse doesn't support linear algebra yet...")
     x = gen_rand((3, 5), backend)
     Ux = modified_gram_schmidt(x)
-    y = ar.do('sum', Ux @ ar.dag(Ux))
+    y = ar.do("sum", Ux @ ar.dag(Ux))
     assert ar.to_numpy(y) == pytest.approx(3)
 
 
 def modified_gram_schmidt_np_mimic(X):
     from autoray import numpy as np
+
     print(np)
 
     Q = []
@@ -128,39 +140,39 @@ def modified_gram_schmidt_np_mimic(X):
     return np.stack(Q, axis=0, like=X)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_mgs_np_mimic(backend):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("Sparse doesn't support linear algebra yet...")
     x = gen_rand((3, 5), backend)
     Ux = modified_gram_schmidt_np_mimic(x)
-    y = ar.do('sum', Ux @ ar.dag(Ux))
+    y = ar.do("sum", Ux @ ar.dag(Ux))
     assert ar.to_numpy(y) == pytest.approx(3)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_linalg_svd_square(backend):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("Sparse doesn't support linear algebra yet...")
     x = gen_rand((5, 4), backend)
-    U, s, V = ar.do('linalg.svd', x)
+    U, s, V = ar.do("linalg.svd", x)
     assert (
-        ar.infer_backend(x) ==
-        ar.infer_backend(U) ==
-        ar.infer_backend(s) ==
-        ar.infer_backend(V) ==
-        backend
+        ar.infer_backend(x)
+        == ar.infer_backend(U)
+        == ar.infer_backend(s)
+        == ar.infer_backend(V)
+        == backend
     )
-    y = U @ ar.do('diag', s, like=x) @ V
-    diff = ar.do('sum', abs(y - x))
+    y = U @ ar.do("diag", s, like=x) @ V
+    diff = ar.do("sum", abs(y - x))
     assert ar.to_numpy(diff) < 1e-8
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_translator_random_uniform(backend):
     from autoray import numpy as anp
 
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("Sparse will have zeros")
 
     x = anp.random.uniform(low=-10, size=(4, 5), like=backend)
@@ -172,12 +184,13 @@ def test_translator_random_uniform(backend):
     assert 1000 <= ar.to_numpy(x) < 2000
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_translator_random_normal(backend):
     from autoray import numpy as anp
+
     x = anp.random.normal(100.0, 0.1, size=(4, 5), like=backend)
 
-    if backend == 'sparse':
+    if backend == "sparse":
         assert (x.data > 90.0).all()
         assert (x.data < 110.0).all()
         return
@@ -185,10 +198,16 @@ def test_translator_random_normal(backend):
     assert (ar.to_numpy(x) > 90.0).all()
     assert (ar.to_numpy(x) < 110.0).all()
 
-    if backend == 'tensorflow':
-        x32 = ar.do('random.normal', 100.0, 0.1, dtype='float32',
-                    size=(4, 5), like=backend)
-        assert x32.dtype == 'float32'
+    if backend == "tensorflow":
+        x32 = ar.do(
+            "random.normal",
+            100.0,
+            0.1,
+            dtype="float32",
+            size=(4, 5),
+            like=backend,
+        )
+        assert x32.dtype == "float32"
         assert (ar.to_numpy(x32) > 90.0).all()
         assert (ar.to_numpy(x32) < 110.0).all()
 
@@ -197,100 +216,102 @@ def test_translator_random_normal(backend):
     assert 1000 <= ar.to_numpy(x) < 2000
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_tril(backend):
     x = gen_rand((4, 4), backend)
-    xl = ar.do('tril', x)
+    xl = ar.do("tril", x)
     xln = ar.to_numpy(xl)
     assert xln[0, 1] == 0.0
-    if backend != 'sparse':
+    if backend != "sparse":
         # this won't work for sparse because density < 1
         assert (xln > 0.0).sum() == 10
-    xl = ar.do('tril', x, k=1)
+    xl = ar.do("tril", x, k=1)
     xln = ar.to_numpy(xl)
-    if backend != 'sparse':
+    if backend != "sparse":
         # this won't work for sparse because density < 1
         assert xln[0, 1] != 0.0
     assert xln[0, 2] == 0.0
-    if backend != 'sparse':
+    if backend != "sparse":
         # this won't work for sparse because density < 1
         assert (xln > 0.0).sum() == 13
 
-    if backend == 'tensorflow':
+    if backend == "tensorflow":
         with pytest.raises(ValueError):
-            ar.do('tril', x, -1)
+            ar.do("tril", x, -1)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_triu(backend):
     x = gen_rand((4, 4), backend)
-    xl = ar.do('triu', x)
+    xl = ar.do("triu", x)
     xln = ar.to_numpy(xl)
     assert xln[1, 0] == 0.0
-    if backend != 'sparse':
+    if backend != "sparse":
         # this won't work for sparse because density < 1
         assert (xln > 0.0).sum() == 10
-    xl = ar.do('triu', x, k=-1)
+    xl = ar.do("triu", x, k=-1)
     xln = ar.to_numpy(xl)
-    if backend != 'sparse':
+    if backend != "sparse":
         # this won't work for sparse because density < 1
         assert xln[1, 0] != 0.0
     assert xln[2, 0] == 0.0
-    if backend != 'sparse':
+    if backend != "sparse":
         # this won't work for sparse because density < 1
         assert (xln > 0.0).sum() == 13
 
-    if backend == 'tensorflow':
+    if backend == "tensorflow":
         with pytest.raises(ValueError):
-            ar.do('triu', x, 1)
+            ar.do("triu", x, 1)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('shape', [(4, 3), (4, 4), (3, 4)])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("shape", [(4, 3), (4, 4), (3, 4)])
 def test_qr_thin_square_fat(backend, shape):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("Sparse doesn't support linear algebra yet...")
     x = gen_rand(shape, backend)
-    Q, R = ar.do('linalg.qr', x)
+    Q, R = ar.do("linalg.qr", x)
     xn, Qn, Rn = map(ar.to_numpy, (x, Q, R))
-    assert ar.do('allclose', xn, Qn @ Rn)
+    assert ar.do("allclose", xn, Qn @ Rn)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('array_dtype', ['int', 'float', 'bool'])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("array_dtype", ["int", "float", "bool"])
 def test_count_nonzero(backend, array_dtype):
 
-    if backend == 'mars':
+    if backend == "mars":
         import mars
-        if mars._version.version_info < (0, 4, 0, ''):
-            pytest.xfail('mars count_nonzero bug fixed in version 0.4.')
 
+        if mars._version.version_info < (0, 4, 0, ""):
+            pytest.xfail("mars count_nonzero bug fixed in version 0.4.")
 
-    if array_dtype == 'int':
-        x = ar.do('array', [0, 1, 2, 0, 3], like=backend)
-    elif array_dtype == 'float':
-        x = ar.do('array', [0., 1., 2., 0., 3.], like=backend)
-    elif array_dtype == 'bool':
-        x = ar.do('array', [False, True, True, False, True], like=backend)
-    nz = ar.do('count_nonzero', x)
+    if array_dtype == "int":
+        x = ar.do("array", [0, 1, 2, 0, 3], like=backend)
+    elif array_dtype == "float":
+        x = ar.do("array", [0.0, 1.0, 2.0, 0.0, 3.0], like=backend)
+    elif array_dtype == "bool":
+        x = ar.do("array", [False, True, True, False, True], like=backend)
+    nz = ar.do("count_nonzero", x)
     assert ar.to_numpy(nz) == 3
 
 
 def test_pseudo_submodules():
-    x = gen_rand((2, 3), 'numpy')
-    xT = ar.do('numpy.transpose', x, like='autoray')
+    x = gen_rand((2, 3), "numpy")
+    xT = ar.do("numpy.transpose", x, like="autoray")
     assert xT.shape == (3, 2)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('creation', ['ones', 'zeros'])
-@pytest.mark.parametrize('dtype', ['float32', 'float64',
-                                   'complex64', 'complex128'])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("creation", ["ones", "zeros"])
+@pytest.mark.parametrize(
+    "dtype", ["float32", "float64", "complex64", "complex128"]
+)
 def test_dtype_specials(backend, creation, dtype):
     import numpy as np
+
     x = ar.do(creation, shape=(2, 3), like=backend)
 
-    if backend == 'torch' and 'complex' in dtype:
+    if backend == "torch" and "complex" in dtype:
         pytest.xfail("Pytorch doesn't support complex numbers yet...")
 
     x = ar.astype(x, dtype)
@@ -300,38 +321,47 @@ def test_dtype_specials(backend, creation, dtype):
     assert ar.get_dtype_name(x) == dtype
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('real_dtype', ['float32', 'float64'])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("real_dtype", ["float32", "float64"])
 def test_complex_creation(backend, real_dtype):
-    if backend == 'torch':
+    if backend == "torch":
         pytest.xfail("Pytorch doesn't support complex numbers yet...")
-    if (backend == 'sparse') and (real_dtype == 'float32'):
-        pytest.xfail("Bug in sparse where single precision isn't maintained "
-                     "after scalar multiplication.")
+    if (backend == "sparse") and (real_dtype == "float32"):
+        pytest.xfail(
+            "Bug in sparse where single precision isn't maintained "
+            "after scalar multiplication."
+        )
 
     x = ar.do(
-        'complex',
-        ar.astype(ar.do('random.uniform', size=(3, 4),
-                        like=backend), real_dtype),
-        ar.astype(ar.do('random.uniform', size=(3, 4),
-                        like=backend), real_dtype)
+        "complex",
+        ar.astype(
+            ar.do("random.uniform", size=(3, 4), like=backend), real_dtype
+        ),
+        ar.astype(
+            ar.do("random.uniform", size=(3, 4), like=backend), real_dtype
+        ),
     )
-    assert ar.get_dtype_name(x) == {'float32': 'complex64',
-                                    'float64': 'complex128'}[real_dtype]
+    assert (
+        ar.get_dtype_name(x)
+        == {"float32": "complex64", "float64": "complex128"}[real_dtype]
+    )
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('dtype_in,dtype_out', [
-    ('float32', 'float32'),
-    ('float64', 'float64'),
-    ('complex64', 'float32'),
-    ('complex128', 'float64'),
-])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "dtype_in,dtype_out",
+    [
+        ("float32", "float32"),
+        ("float64", "float64"),
+        ("complex64", "float32"),
+        ("complex128", "float64"),
+    ],
+)
 def test_real_imag(backend, dtype_in, dtype_out):
     x = gen_rand((3, 4), backend, dtype_in)
 
-    re = ar.do('real', x)
-    im = ar.do('imag', x)
+    re = ar.do("real", x)
+    im = ar.do("imag", x)
 
     assert ar.infer_backend(re) == backend
     assert ar.infer_backend(im) == backend
@@ -339,52 +369,62 @@ def test_real_imag(backend, dtype_in, dtype_out):
     assert ar.get_dtype_name(re) == dtype_out
     assert ar.get_dtype_name(im) == dtype_out
 
-    assert ar.do('allclose', ar.to_numpy(x).real, ar.to_numpy(re))
-    assert ar.do('allclose', ar.to_numpy(x).imag, ar.to_numpy(im))
+    assert ar.do("allclose", ar.to_numpy(x).real, ar.to_numpy(re))
+    assert ar.do("allclose", ar.to_numpy(x).imag, ar.to_numpy(im))
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('dtype', [
-    'float32', 'float64',
-    'complex64', 'complex128',
-])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+    ],
+)
 def test_linalg_solve(backend, dtype):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("Sparse doesn't support linear algebra yet...")
 
     A = gen_rand((4, 4), backend, dtype)
     b = gen_rand((4, 1), backend, dtype)
-    x = ar.do('linalg.solve', A, b)
-    assert ar.do('allclose', ar.to_numpy(A @ x), ar.to_numpy(b), rtol=1e-4)
+    x = ar.do("linalg.solve", A, b)
+    assert ar.do("allclose", ar.to_numpy(A @ x), ar.to_numpy(b), rtol=1e-4)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
-@pytest.mark.parametrize('dtype', [
-    'float32', 'float64',
-    'complex64', 'complex128',
-])
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+    ],
+)
 def test_linalg_eigh(backend, dtype):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("sparse doesn't support linalg.eigh yet.")
-    if backend == 'dask':
+    if backend == "dask":
         pytest.xfail("dask doesn't support linalg.eigh yet.")
-    if backend == 'mars':
+    if backend == "mars":
         pytest.xfail("mars doesn't support linalg.eigh yet.")
-    if (backend == 'torch') and ('complex' in dtype):
+    if (backend == "torch") and ("complex" in dtype):
         pytest.xfail("Pytorch doesn't fully support complex yet.")
 
     A = gen_rand((4, 4), backend, dtype)
     A = A + ar.dag(A)
-    el, ev = ar.do('linalg.eigh', A)
+    el, ev = ar.do("linalg.eigh", A)
     B = (ev * ar.reshape(el, (1, -1))) @ ar.dag(ev)
-    assert ar.do('allclose', ar.to_numpy(A), ar.to_numpy(B), rtol=1e-3)
+    assert ar.do("allclose", ar.to_numpy(A), ar.to_numpy(B), rtol=1e-3)
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_pad(backend):
-    if backend == 'sparse':
+    if backend == "sparse":
         pytest.xfail("sparse doesn't support linalg.eigh yet.")
-    if backend == 'mars':
+    if backend == "mars":
         pytest.xfail("mars doesn't support linalg.eigh yet.")
 
     A = gen_rand((3, 4, 5), backend)
@@ -395,29 +435,27 @@ def test_pad(backend):
         # same pad for every axis
         (((1, 2),), (6, 7, 8)),
         # different pad for every axis
-        (((4, 3), (2, 4), (3, 2)), (10, 10, 10))
+        (((4, 3), (2, 4), (3, 2)), (10, 10, 10)),
     ]:
-        B = ar.do('pad', A, pad_width)
+        B = ar.do("pad", A, pad_width)
         assert B.shape == new_shape
-        assert (
-            ar.to_numpy(ar.do("sum", A)) ==
-            pytest.approx(ar.to_numpy(ar.do("sum", B)))
+        assert ar.to_numpy(ar.do("sum", A)) == pytest.approx(
+            ar.to_numpy(ar.do("sum", B))
         )
 
 
-@pytest.mark.parametrize('backend', BACKENDS)
+@pytest.mark.parametrize("backend", BACKENDS)
 def test_register_function(backend):
-    x = ar.do('ones', shape=(2, 3), like=backend)
+    x = ar.do("ones", shape=(2, 3), like=backend)
 
     def direct_fn(x):
         return 1
 
     # first test we can provide the function directly
-    ar.register_function(backend, 'test_register', direct_fn)
-    assert ar.do('test_register', x) == 1
+    ar.register_function(backend, "test_register", direct_fn)
+    assert ar.do("test_register", x) == 1
 
     def wrap_fn(fn):
-
         def new_fn(*args, **kwargs):
             res = fn(*args, **kwargs)
             return res + 1
@@ -425,5 +463,78 @@ def test_register_function(backend):
         return new_fn
 
     # then check we can wrap the old (previous) function
-    ar.register_function(backend, 'test_register', wrap_fn, wrap=True)
-    assert ar.do('test_register', x) == 2
+    ar.register_function(backend, "test_register", wrap_fn, wrap=True)
+    assert ar.do("test_register", x) == 2
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_take(backend):
+    if backend == "sparse":
+        pytest.xfail("sparse doesn't support take yet")
+    num_inds = 4
+    A = gen_rand((2, 3, 4), backend)
+    if backend == "jax":  # gen_rand doesn't work with ints for JAX
+        ind = gen_rand((num_inds,), "numpy", dtype="int64")
+    else:
+        ind = gen_rand((num_inds,), backend, dtype="int64")
+
+    # Take along axis 1, and check if result makes sense
+    B = ar.do("take", A, ind, axis=1)
+    assert B.shape == (2, 4, 4)
+    for i in range(num_inds):
+        assert ar.do(
+            "allclose", ar.to_numpy(A[:, ind[0], :]), ar.to_numpy(B[:, 0, :])
+        )
+    assert ar.infer_backend(A) == ar.infer_backend(B)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_concatenate(backend):
+    mats = [gen_rand((2, 3, 4), backend) for _ in range(3)]
+
+    # Concatenate along axis 1, check if shape is correct
+    # also check if automatically inferring backend works
+    mats_concat1 = ar.do("concatenate", mats, axis=1)
+    mats_concat2 = ar.do("concatenate", mats, axis=1, like=backend)
+    assert mats_concat1.shape == mats_concat2.shape == (2, 9, 4)
+    assert (
+        backend
+        == ar.infer_backend(mats_concat1)
+        == ar.infer_backend(mats_concat2)
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_stack(backend):
+    mats = [gen_rand((2, 3, 4), backend) for _ in range(3)]
+
+    # stack, creating a new axis (at position 0)
+    # also check if automatically inferring backend works
+    mats_stack1 = ar.do("stack", mats)
+    mats_stack2 = ar.do("stack", mats, like=backend)
+    assert mats_stack1.shape == mats_stack2.shape == (3, 2, 3, 4)
+    assert (
+        backend
+        == ar.infer_backend(mats_stack1)
+        == ar.infer_backend(mats_stack2)
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_einsum(backend):
+    if backend == "sparse":
+        pytest.xfail("sparse doesn't support einsum yet")
+    A = gen_rand((2, 3, 4), backend)
+    B = gen_rand((3, 4, 2), backend)
+    C1 = ar.do("einsum", "ijk,jkl->il", A, B, like=backend)
+    C2 = ar.do("einsum", "ijk,jkl->il", A, B)
+    C3 = ar.do("reshape", A, (2, 12)) @ ar.do("reshape", B, (12, 2))
+    assert C1.shape == C2.shape == (2, 2)
+    assert ar.do("allclose", ar.to_numpy(C1), ar.to_numpy(C3))
+    assert ar.do("allclose", ar.to_numpy(C2), ar.to_numpy(C3))
+    assert (
+        ar.infer_backend(C1)
+        == ar.infer_backend(C2)
+        == ar.infer_backend(C3)
+        == backend
+    )

--- a/tests/test_autoray.py
+++ b/tests/test_autoray.py
@@ -528,7 +528,10 @@ def test_einsum(backend):
     B = gen_rand((3, 4, 2), backend)
     C1 = ar.do("einsum", "ijk,jkl->il", A, B, like=backend)
     C2 = ar.do("einsum", "ijk,jkl->il", A, B)
-    C3 = ar.do("einsum", A, [0, 1, 2], B, [1, 2, 3], [1, 3])
+    if backend not in ("torch", "tensorflow"):  # this syntax is not supported
+        C3 = ar.do("einsum", A, [0, 1, 2], B, [1, 2, 3], [0, 3])
+    else:
+        C3 = C1
     C4 = ar.do("reshape", A, (2, 12)) @ ar.do("reshape", B, (12, 2))
 
     assert C1.shape == C2.shape == C3.shape == (2, 2)


### PR DESCRIPTION
I implemented custom dispatchers as discussed in #3.

-----------------

I wrote some tests to confirm it works as expected. One potential caveat, functions like `np.stack` can also eat a one-dimensional array, in which case it acts like the identity function. In those cases backend is inferred from first element of this one-dimensional array by `join_array_dispatcher`. This works correctly for all supported backends except sparse, where backend is inferred as numpy.  This is however not the intended usage of `stack` anyway, so I don't think this is a problem.

----------------

For `join_array_dispatcher`  we could optionally check if `args[0][0]` even exists in the first place, and if not just return `args[0]`. This is only relevant if you want to supply it empty sequences or 0-dimensional arrays (which numpy doesn't allow, for example). 
If so, one can check this with `hasattr(args[0], '__getitem__')`. This is a bit nicer than a try: / except: block, especially since we have to catch both IndexErrors and TypeErrors. 

----------------

It seems my auto formatter `black`  was wreaking havoc on your code. Biggest thing it did is replacing single quotes for double quotes everywhere. If this bothers you, I will do a commit with only my actual changes. Otherwise, do you use a particular auto formatter for this project?

----------------

I also took the liberty of adding translations for `np.take`. I'm a bit confused about the syntax of `make_translator`. For torch implementation of `take` (i.e. `index_select`) the names of arguments and order of arguments is both different, and I'm not 100% sure I did it correctly (at least it seems to work). 