### PR TITLE
split and where translations

### DIFF
--- a/autoray/autoray.py
+++ b/autoray/autoray.py
@@ -986,7 +986,8 @@ def torch_split_wrap(fn):
     @functools.wraps(fn)
     def numpy_like(ary, indices_or_sections, axis=0, **kwargs):
         if isinstance(indices_or_sections, int):
-            return fn(ary, indices_or_sections, dim=axis, **kwargs)
+            split_size = ary.shape[axis] // indices_or_sections
+            return fn(ary, split_size, dim=axis, **kwargs)
         else:
             diff = do(
                 "diff",

--- a/tests/test_autoray.py
+++ b/tests/test_autoray.py
@@ -545,3 +545,31 @@ def test_einsum(backend):
         == ar.infer_backend(C4)
         == backend
     )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_split(backend):
+    if backend == "sparse":
+        pytest.xfail("sparse doesn't support split yet")
+    if backend == "dask":
+        pytest.xfail("dask doesn't support split yet")
+    A = ar.do("ones", (10, 20, 10), like=backend)
+    sections = [2, 4, 14]
+    splits = ar.do("split", A, sections, axis=1)
+    assert len(splits) == 4
+    assert splits[3].shape == (10, 6, 10)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_where(backend):
+    if backend == "sparse":
+        pytest.xfail("sparse doesn't support where yet")
+    A = ar.do("arange", 10, like=backend)
+    B = ar.do("arange", 10, like=backend) + 1
+    C = ar.do("stack", [A, B])
+    D = ar.do("where", C < 5)
+    if backend == "dask":
+        for x in D:
+            x.compute_chunk_sizes()
+    for x in D:
+        assert ar.to_numpy(x).shape == (9,)

--- a/tests/test_autoray.py
+++ b/tests/test_autoray.py
@@ -548,16 +548,22 @@ def test_einsum(backend):
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-def test_split(backend):
+@pytest.mark.parametrize("int_or_section", ["int", "section"])
+def test_split(backend, int_or_section):
     if backend == "sparse":
         pytest.xfail("sparse doesn't support split yet")
     if backend == "dask":
         pytest.xfail("dask doesn't support split yet")
     A = ar.do("ones", (10, 20, 10), like=backend)
-    sections = [2, 4, 14]
-    splits = ar.do("split", A, sections, axis=1)
-    assert len(splits) == 4
-    assert splits[3].shape == (10, 6, 10)
+    if int_or_section == 'section':
+        sections = [2, 4, 14]
+        splits = ar.do("split", A, sections, axis=1)
+        assert len(splits) == 4
+        assert splits[3].shape == (10, 6, 10)
+    else:
+        splits = ar.do("split", A, 5, axis=2)
+        assert len(splits) == 5
+        assert splits[2].shape == (10, 20, 2)
 
 
 @pytest.mark.parametrize("backend", BACKENDS)


### PR DESCRIPTION
As mentioned in #5 

- Translating `np.diff` didn't seem worthwhile. There is `tf.experimental.numpy.diff`, but it's only on newest version of tensorflow, and probably in a later version it will become just `tf.diff`. 
- Torch and tensorflow wrappers for `split` can probably be unified into one function, but this would mean wrapping a translation around the wrapper I made for torch since syntax is slightly different. Both typically take a list as input if using sections to split the array, so I don't think my wrapper brings that much extra overhead.
- For torch I didn't use `tensor_split` since it's not yet in the stable release. Maybe one can do different things in autoray depending on torch version number, but that doesn't seem very elegant. 
- I couldn't run any of the CuPy tests on this machine since it doesn't have a GPU