### PR TITLE
with_dtype wrapper

### DIFF
--- a/autoray/autoray.py
+++ b/autoray/autoray.py
@@ -333,7 +333,7 @@ def triu_to_band_part(fn):
 
 def scale_random_uniform_manually(fn):
     @functools.wraps(fn)
-    def numpy_like(low=0.0, high=1.0, size=None, **kwargs):
+    def numpy_like(low=0.0, high=1.0, size=None, dtype=None, **kwargs):
         if size is None:
             size = ()
 
@@ -342,6 +342,8 @@ def scale_random_uniform_manually(fn):
         if (low != 0.0) or (high != 1.0):
             x = (high - low) * x + low
 
+        if (dtype is not None) and get_dtype_name(x) != dtype:
+            x = astype(x, dtype)
         return x
 
     return numpy_like
@@ -349,7 +351,7 @@ def scale_random_uniform_manually(fn):
 
 def scale_random_normal_manually(fn):
     @functools.wraps(fn)
-    def numpy_like(loc=0.0, scale=1.0, size=None, **kwargs):
+    def numpy_like(loc=0.0, scale=1.0, size=None, dtype=None, **kwargs):
         if size is None:
             size = ()
 
@@ -358,26 +360,27 @@ def scale_random_normal_manually(fn):
         if (loc != 0.0) or (scale != 1.0):
             x = scale * x + loc
 
+        if (dtype is not None) and get_dtype_name(x) != dtype:
+            x = astype(x, dtype)
         return x
 
     return numpy_like
 
 
-def with_dtype_wrapper(fn, standard_type):
-    """Add ability to handle `dtype` keyword."""
+def with_dtype_wrapper(fn):
+    """Add ability to handle `dtype` keyword.
+    If not None, `dtype` should be specified as a string, otherwise conversion
+    will happen regardless.
+    """
 
     @functools.wraps(fn)
     def with_dtype(*args, dtype=None, **kwargs):
         A = fn(*args, **kwargs)
-        if (dtype is not None) and (dtype != standard_type):
+        if (dtype is not None) and (dtype != get_dtype_name(A)):
             A = astype(A, dtype)
         return A
 
     return with_dtype
-
-
-def make_with_dtype(standard_type):
-    return functools.partial(with_dtype_wrapper, standard_type=standard_type)
 
 
 def translate_wrapper(fn, translator):
@@ -565,9 +568,8 @@ _FUNCS["numpy", "complex"] = complex_add_re_im
 _FUNCS["builtins", "to_numpy"] = numpy_to_numpy
 _SUBMODULE_ALIASES["numpy", "linalg.expm"] = "scipy.linalg"
 _CUSTOM_WRAPPERS["numpy", "linalg.svd"] = svd_not_full_matrices_wrapper
-_CUSTOM_WRAPPERS["numpy", "random.normal"] = make_with_dtype("float64")
-_CUSTOM_WRAPPERS["numpy", "random.uniform"] = make_with_dtype("float64")
-
+_CUSTOM_WRAPPERS["numpy", "random.normal"] = with_dtype_wrapper
+_CUSTOM_WRAPPERS["numpy", "random.uniform"] = with_dtype_wrapper
 
 # ---------------------------------- cupy ----------------------------------- #
 
@@ -663,14 +665,23 @@ def dask_to_numpy(x):
     return x.compute()
 
 
+def dask_eye_wrapper(fn):
+    # Make M work as positional argument
+    @functools.wraps(fn)
+    def numpy_like(N, M=None, **kwargs):
+        return fn(N, M=M, **kwargs)
+
+    return numpy_like
+
+
 _FUNCS["dask", "to_numpy"] = dask_to_numpy
 _FUNCS["dask", "complex"] = complex_add_re_im
 _FUNC_ALIASES["dask", "abs"] = "absolute"
 _MODULE_ALIASES["dask"] = "dask.array"
 _CUSTOM_WRAPPERS["dask", "linalg.svd"] = svd_manual_full_matrices_kwarg
-_CUSTOM_WRAPPERS["dask", "random.normal"] = make_with_dtype("float64")
-_CUSTOM_WRAPPERS["dask", "random.uniform"] = make_with_dtype("float64")
-
+_CUSTOM_WRAPPERS["dask", "random.normal"] = with_dtype_wrapper
+_CUSTOM_WRAPPERS["dask", "random.uniform"] = with_dtype_wrapper
+_CUSTOM_WRAPPERS["dask", "eye"] = dask_eye_wrapper
 
 # ---------------------------------- mars ----------------------------------- #
 
@@ -1027,6 +1038,29 @@ def torch_split_wrap(fn):
     return numpy_like
 
 
+def torch_zeros_ones_wrap(fn):
+    @functools.wraps(fn)
+    def numpy_like(shape, dtype=None, **kwargs):
+        if dtype is not None:
+            dtype = to_backend_dtype(dtype, like="torch")
+        return fn(shape, dtype=dtype)
+
+    return numpy_like
+
+
+def torch_eye_wrap(fn):
+    @functools.wraps(fn)
+    def numpy_like(N, M=None, dtype=None, **kwargs):
+        if dtype is not None:
+            dtype = to_backend_dtype(dtype, like="torch")
+        if M is not None:
+            return fn(N, m=M, dtype=dtype)
+        else:
+            return fn(N, dtype=dtype)
+
+    return numpy_like
+
+
 _FUNCS["torch", "pad"] = torch_pad
 _FUNCS["torch", "real"] = torch_real
 _FUNCS["torch", "imag"] = torch_imag
@@ -1089,16 +1123,9 @@ _CUSTOM_WRAPPERS["torch", "clip"] = make_translator(
         ("a_max", ("max",)),
     ]
 )
-_CUSTOM_WRAPPERS["torch", "ones"] = make_translator(
-    [
-        ("shape", ("size",)),
-    ]
-)
-_CUSTOM_WRAPPERS["torch", "zeros"] = make_translator(
-    [
-        ("shape", ("size",)),
-    ]
-)
+_CUSTOM_WRAPPERS["torch", "ones"] = torch_zeros_ones_wrap
+_CUSTOM_WRAPPERS["torch", "zeros"] = torch_zeros_ones_wrap
+_CUSTOM_WRAPPERS["torch", "eye"] = torch_eye_wrap
 _CUSTOM_WRAPPERS["torch", "empty"] = make_translator(
     [
         ("shape", ("size",)),

--- a/tests/test_autoray.py
+++ b/tests/test_autoray.py
@@ -555,7 +555,7 @@ def test_split(backend, int_or_section):
     if backend == "dask":
         pytest.xfail("dask doesn't support split yet")
     A = ar.do("ones", (10, 20, 10), like=backend)
-    if int_or_section == 'section':
+    if int_or_section == "section":
         sections = [2, 4, 14]
         splits = ar.do("split", A, sections, axis=1)
         assert len(splits) == 4
@@ -579,3 +579,19 @@ def test_where(backend):
             x.compute_chunk_sizes()
     for x in D:
         assert ar.to_numpy(x).shape == (9,)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_dtype_kwarg(backend, dtype):
+    dtype = ar.to_backend_dtype(dtype, backend)
+    A = ar.do("random.normal", size=(10, 10), dtype=dtype, like=backend)
+    assert A.dtype == dtype
+    A = ar.do("random.uniform", size=(10, 10), dtype=dtype, like=backend)
+    assert A.dtype == dtype
+    A = ar.do("zeros", shape=(10, 10), dtype=dtype, like=backend)
+    assert A.dtype == dtype
+    A = ar.do("ones", shape=(10, 10), dtype=dtype, like=backend)
+    assert A.dtype == dtype
+    A = ar.do("eye", 10, dtype=dtype, like=backend)
+    assert A.dtype == dtype


### PR DESCRIPTION
fixes #7 

This seems to work. Only thing I'm not satisfied with is the comparison 
```python
A = fn(*args, **kwargs)
if (dtype is not None) and (dtype != standard_type):
    ...
```
For example if `standard_dtype='float64'` and `dtype=np.float64` this will still trigger, but it shouldn't.
I have three ways around this:
- Store `standard_type` not as string but as backend specific dtype object. Then compare standard_type` to `A.dtype` instead.
- Compare `standard_type` to `get_dtype_name(A)`. 
- Make a cached function for dtype comparisons across backends