### PR TITLE
Add: `take` function and getitem for lazyarray

### DIFF
--- a/autoray/lazy/__init__.py
+++ b/autoray/lazy/__init__.py
@@ -21,6 +21,7 @@ from .core import (
     concatenate,
     split,
     where,
+    take,
     # binary
     multiply,
     add,
@@ -82,6 +83,7 @@ __all__ = (
     "concatenate",
     "split",
     "where",
+    "take",
     # binary functions
     "multiply",
     "add",

--- a/autoray/lazy/core.py
+++ b/autoray/lazy/core.py
@@ -1046,7 +1046,7 @@ def getitem(a, key):
             newshape.append(len(range(d)[k]))
         else:
             try:
-                newshape = indices_shape_for_lazy(k)
+                newshape = _get_py_shape(k)
             except TypeError:
                 pass
 
@@ -1267,17 +1267,21 @@ def where(condition, x, y):
     )
 
 
-def indices_shape_for_lazy(indices):
-    import numpy as np
-    shape_list = list(np.array(indices).shape)
-    return shape_list
+def _get_py_shape(x):
+    """Infer the shape of a possibly nested list/tuple object.
+    """
+    if hasattr(x, "shape"):
+        return list(x.shape)
+    if isinstance(x, (tuple, list)):
+        return [len(x)] + _get_py_shape(x[0])
+    return []
 
 
 @lazy_cache('take')
 def take(x, indices):
     x = ensure_lazy(x)
     if isinstance(indices, (list, tuple)):
-        new_shape = indices_shape_for_lazy(indices)
+        new_shape = _get_py_shape(indices)
     else:
         indices = ensure_lazy(indices)
         new_shape = indices.shape

--- a/autoray/lazy/core.py
+++ b/autoray/lazy/core.py
@@ -1268,21 +1268,8 @@ def where(condition, x, y):
 
 
 def indices_shape_for_lazy(indices):
-    shape_list = []
-
-    def helper(sequence):
-        if isinstance(sequence, (list, tuple)):
-            if all(isinstance(x, int) for x in sequence):
-                shape_list.append(len(sequence))
-            elif all((isinstance(x, (list, tuple)) and len(x) == len(sequence[0])) for x in sequence):
-                shape_list.append(len(sequence))
-                helper(sequence[0])
-            else:
-                raise ValueError(
-                    'setting an array element with a sequence. '
-                )
-
-    helper(indices)
+    import numpy as np
+    shape_list = list(np.array(indices).shape)
     return shape_list
 
 

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -472,3 +472,65 @@ def test_where():
     y = do("asarray", [1, 2, 3, 4], like="numpy")
     z = f([x, y])
     assert_allclose(z, [1, 1, 3, 4])
+
+
+@pytest.mark.parametrize(
+    "indices",
+    [
+        [0, 1],
+        [[0, 1], [1, 2]],
+        [[[0, 1], [1, 2]], [[1, 1], [2, 2]]],
+        [[[[0, 1, 2, 3]]]],
+        [[[[0], [1]]], [[[2], [3]]]]
+    ],
+)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4,),
+        (4, 5),
+        (4, 5, 6),
+        (4, 5, 6, 7),
+    ],
+)
+def test_take(indices, shape):
+    a = do("random.uniform", size=shape, like="numpy")
+    b = lazy.Variable(shape=shape, backend="numpy")
+    np_shape = do("take", a, indices).shape
+    lazy_shape = do("take", b, indices).shape
+
+    fn = do("take", b, indices).get_function([b])
+    lazy_func_shape = fn([a]).shape
+    assert_allclose(np_shape, lazy_shape)
+    assert_allclose(np_shape, lazy_func_shape)
+
+
+@pytest.mark.parametrize(
+    "indices",
+    [
+        [0, 1],
+        [[0, 1], [1, 2]],
+        [[[0, 1], [1, 2]], [[1, 1], [2, 2]]],
+        [[[[0, 1, 2, 3]]]],
+        [[[[0], [1]]], [[[2], [3]]]]
+    ],
+)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4,),
+        (4, 5),
+        (4, 5, 6),
+        (4, 5, 6, 7),
+    ],
+)
+def test_getitem(indices, shape):
+    a = do("random.uniform", size=shape, like="numpy")
+    b = lazy.Variable(shape=shape, backend="numpy")
+    np_shape = a[indices].shape
+    lazy_shape = b[indices].shape
+
+    fn = b[indices].get_function([b])
+    lazy_func_shape = fn([a]).shape
+    assert_allclose(np_shape, lazy_shape)
+    assert_allclose(np_shape, lazy_func_shape)


### PR DESCRIPTION
Hi @jcmgray Johnnie. I have implemented both of the `autoray.lazy.take` and fancy indexing of `autoray.lazy.getiem`

For `autoray.lazy.take`, I have considered following two situations
1.  Indices may be `list` or `tuple`,
2.  The indices may be LazyArray, or indices should be backend-type array. For instance, the indices should be `torch.Tensor` for `torch.take`.

For `autoray.lazy.getitem`, the indices can only be the `list` or `tuple`, and raise the exception when the indices is wrong for LazyArray.

I'm not sure that I covered all the complicated cases for these two functions, these all can be further improved
