### PR TITLE
fix: matmul shape for lazy

### DIFF
--- a/autoray/lazy/core.py
+++ b/autoray/lazy/core.py
@@ -1377,7 +1377,10 @@ def matmul(x1, x2):
 
     shape1 = shape(x1)
     shape2 = shape(x2)
-    newshape = (*shape1[:-2], shape1[-2], shape2[-1])
+    if len(shape2) == 1:
+        newshape = shape1[:-1]
+    else:
+        newshape = (*shape1[:-1], shape2[-1])
 
     return LazyArray(
         backend=backend,


### PR DESCRIPTION
Fix the shape of lazy after matmul
```
from autoray.lazy import Variable
import numpy as np
a = Variable(shape=(4, 3))
b = Variable(shape=(3, ))
print(a@b)
# <LazyArray(fn=matmul, shape=(4, 3), backend='None')>

a = np.random.rand(4, 3)
b = np.random.rand(3)
print((a@b).shape)
# (4,)
```