### PR TITLE
Correct a simple but important typo in readme and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ name followed by `*args` and `**kwargs`, and automatically looks up (and
 caches) the correct function to match the equivalent numpy call:
 
 ```python
-from autoray as ar
+import autoray as ar
 
 def noised_svd(x):
     # automatic dispatch based on supplied array

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ name followed by `*args` and `**kwargs`, and automatically looks up (and
 caches) the correct function to match the equivalent numpy call:
 
 ```python
-from autoray as ar
+import autoray as ar
 
 def noised_svd(x):
     # automatic dispatch based on supplied array


### PR DESCRIPTION
Correct `from autoray as ar` to `import autoray as ar`