### PR TITLE
add stop_gradient

### DIFF
--- a/autoray/__init__.py
+++ b/autoray/__init__.py
@@ -63,6 +63,7 @@ from .autoray import (
     tree_unflatten,
 )
 from .compiler import autojit
+from .grad import stop_gradient
 
 __all__ = (
     "do",
@@ -104,6 +105,8 @@ __all__ = (
     "autojit",
     # lazy array library
     "lazy",
+    # grad
+    "stop_gradient",
     # math constants,
     "e",
     "pi",

--- a/autoray/grad.py
+++ b/autoray/grad.py
@@ -1,0 +1,96 @@
+from .autoray import register_function, do
+
+
+_GRAD_BACKENDS = {"jax", "torch", "tensorflow", "paddle", "autograd"}
+_NO_GRAD_BACKENDS = {"numpy", "cupy", "dask", "sparse", "mars"}
+
+
+# -------------------- stop_gradient -------------------- #
+
+
+def jax_stop_gradient(x):
+    from jax.lax import stop_gradient
+
+    return stop_gradient(x)
+
+
+def torch_stop_gradient(x):
+    return x.detach()
+
+
+def tensorflow_stop_gradient(x):
+    import tensorflow as tf
+
+    return tf.stop_gradient(x)
+
+
+def paddle_stop_gradient(x):
+    return x.detach()
+
+
+def autograd_stop_gradient(x):
+    import autograd.numpy as anp
+    from autograd.tracer import getval
+
+    return anp.array(getval(x))
+
+
+def do_nothing(x):
+    """For backends without grad, keep x unchanged."""
+    return x
+
+
+# register for each backend
+register_function("torch", "stop_gradient", torch_stop_gradient)
+register_function("jax", "stop_gradient", jax_stop_gradient)
+register_function("tensorflow", "stop_gradient", tensorflow_stop_gradient)
+register_function("paddle", "stop_gradient", paddle_stop_gradient)
+register_function("autograd", "stop_gradient", autograd_stop_gradient)
+for _backend in _NO_GRAD_BACKENDS:
+    register_function(_backend, "stop_gradient", do_nothing)
+
+
+def stop_gradient(x):
+    """Stop gradient flow through array ``x``.
+
+    In autodiff backends (JAX, PyTorch, TensorFlow, etc.), this detaches
+    ``x`` from the computational graph so that no gradients are propagated
+    through it. For non-autodiff backends (NumPy, CuPy, etc.), this is a
+    no-op and returns ``x`` unchanged.
+
+    Parameters
+    ----------
+    x : array
+        The array to stop gradient flow through.
+
+    Returns
+    -------
+    array
+        An array with the same value as ``x`` but detached from the
+        autodiff computational graph.
+
+    Examples
+    --------
+
+    With JAX::
+
+        >>> import jax, jax.numpy as jnp, autoray as ar
+        >>> x = jnp.array([1.0, 2.0, 3.0])
+        >>> ar.stop_gradient(x)  # equivalent to jax.lax.stop_gradient(x)
+
+    With PyTorch::
+
+        >>> import torch, autoray as ar
+        >>> x = torch.tensor([1.0, 2.0], requires_grad=True)
+        >>> y = ar.stop_gradient(x)  # equivalent to x.detach()
+        >>> y.requires_grad
+        False
+
+    With NumPy (no-op)::
+
+        >>> import numpy as np, autoray as ar
+        >>> x = np.array([1.0, 2.0])
+        >>> ar.stop_gradient(x) is x
+        True
+    """
+    return do("stop_gradient", x)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -3,7 +3,9 @@ from autoray import do
 
 from .test_autoray import BACKENDS, gen_rand
 
-BACKENDS = ("jax", "torch", "tensorflow", "paddle", "autograd")
+
+_GRAD_BACKENDS = ["jax", "torch", "tensorflow", "paddle", "autograd"]
+BACKENDS = [p for p in BACKENDS if p.values[0] in _GRAD_BACKENDS]
 
 
 @pytest.mark.parametrize("backend", BACKENDS)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -1,0 +1,13 @@
+import pytest
+from autoray import do
+
+from .test_autoray import BACKENDS, gen_rand
+
+BACKENDS = ("jax", "torch", "tensorflow", "paddle", "autograd")
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_stop_gradient(backend):
+    x = gen_rand((10, 10), backend)
+    y = do("stop_gradient", x)
+    assert do("allclose", x, y)


### PR DESCRIPTION
Add `stop_gradient` to autoray. For backends with autograd, it stops tracing gradients. Otherwise, it returns the original array.

A new `grad.py` file is created to accommodate possible grad-related functions in the future.

Usage of `stop_gradient`

```
from autoray import do, stop_gradient

# stop grad by do
x = do("stop_gradient", x)

# stop grad by calling stop_gradient
x = stop_gradient(x)
```

To be finished in the future:
- Define `stop_gradient` for `LazyArray`
- Other grad-related functions, including `grad`, `jvp`, `vjp`, `jacobian`, ...