### PR TITLE
add unified "random.array" interface

### DIFF
--- a/autoray/autoray.py
+++ b/autoray/autoray.py
@@ -451,12 +451,12 @@ def _make_device_dtype_dispatch(like):
     # B) cache whether we should check dtype/device since relying on try/except
     # can be unexpectedly slow (https://github.com/jcmgray/autoray/pull/30)
     try:
-        like.device
+        _ = like.device
         has_device = True
     except AttributeError:
         has_device = False
     try:
-        like.dtype
+        _ = like.dtype
         has_dtype = True
     except AttributeError:
         has_dtype = False
@@ -545,6 +545,7 @@ _CREATION_ROUTINES = {
     # composed function, all implementations accept dtype and device
     "from_numpy": (True, True),
     "random.default_rng": (False, False),
+    "random.array": (True, True),
     # mark the following as creation routines despite (False, False) defaults
     # -> so specific backends can optionally inject dtype/device for them
     "array": (False, False),
@@ -2255,6 +2256,141 @@ register_dispatch("true_divide", binary_dispatcher, raw_signature=False)
 register_dispatch("add", binary_dispatcher, raw_signature=False)
 register_dispatch("subtract", binary_dispatcher, raw_signature=False)
 
+
+def random_array_dispatcher(shape, rng=None, **kwargs):
+    """Use the generator's backend when given, or infer it from ``shape``."""
+    if (rng is not None) and not isinstance(rng, numbers.Integral):
+        return _infer_class_backend_cached(rng.__class__)
+    backend = _infer_class_backend_cached(shape.__class__)
+    return "numpy" if backend == "builtins" else backend
+
+
+register_dispatch("random.array", random_array_dispatcher)
+
+
+_RANDOM_DISTS = ("normal", "uniform")
+
+
+def _sample_random_array(rng, dist, shape, dtype_name, device, backend):
+    kwargs = {}
+    if backend in ("cupy", "jax", "numpy", "torch"):
+        # these sample at a given dtype, the rest are cast after sampling
+        kwargs["dtype"] = to_backend_dtype(dtype_name, backend)
+    if (backend == "torch") and (device is not None):
+        kwargs["device"] = device
+
+    if rng is None:
+        # use the backend's shared random state
+        x = do(f"random.{dist}", size=shape, like=backend, **kwargs)
+    elif dist == "normal":
+        if hasattr(rng, "standard_normal"):
+            sample = rng.standard_normal
+        else:
+            sample = rng.normal
+        x = sample(size=shape, **kwargs)
+    else:
+        x = rng.random(size=shape, **kwargs)
+
+    if get_dtype_name(x) != dtype_name:
+        x = astype(x, dtype_name)
+    if (device is not None) and (backend != "torch"):
+        x = to_device(x, device)
+    return x
+
+
+@functools.partial(compose, name="random.array")
+def random_array(
+    shape,
+    dist="normal",
+    loc=0.0,
+    scale=1.0,
+    dtype=None,
+    device=None,
+    rng=None,
+    backend=None,
+):
+    """Generate an array of random samples.
+
+    Parameters
+    ----------
+    shape : tuple[int]
+        Shape of the generated array.
+    dist : {"normal", "uniform"}, optional
+        Distribution to sample before applying ``loc`` and ``scale``.
+    loc : float or complex, optional
+        Location applied after sampling.
+    scale : float or complex, optional
+        Scale applied after sampling.
+    dtype : str or dtype_like, optional
+        Output dtype, defaulting to that inferred from ``like``, or
+        ``float64`` if there is none.
+    device : str or device_like, optional
+        Output device. Defaults to that inferred from ``like``.
+    rng : int or random number generator, optional
+        ``None`` uses the backend's shared random state where one is available.
+        An integer makes a new generator for this call. A backend-specific
+        generator uses and advances its own state, and also supplies the
+        backend, so that ``like`` is not needed. Each backend additionally
+        accepts its own seed and state objects, such as a numpy
+        ``SeedSequence`` or ``BitGenerator``, or a jax key.
+
+    Returns
+    -------
+    array
+        Random samples with ``x = loc + scale * z``. Before this transform, a
+        complex normal ``z`` has total variance one, and a complex uniform
+        ``z`` fills the unit square.
+    """
+    if dist not in _RANDOM_DISTS:
+        raise ValueError(
+            f"Unknown distribution {dist!r}, expected one of {_RANDOM_DISTS}."
+        )
+
+    dtype_name = "float64" if dtype is None else _dtype_to_name_cached(dtype)
+
+    # get a generator from the supplied seed, key, or generator
+    if rng is not None:
+        if backend == "torch":
+            # torch needs the generator and output on the same device
+            rng = do("random.default_rng", rng, device=device, like=backend)
+        else:
+            rng = do("random.default_rng", rng, like=backend)
+    elif backend == "jax":
+        # jax has no shared random state, so use the module level generator
+        rng = _get_jax_default_rng()
+
+    if dtype_name in _COMPLEX_DTYPES:
+        if (dist == "normal") and (backend in ("jax", "torch")):
+            # can sample complex normal directly
+            x = _sample_random_array(
+                rng, dist, shape, dtype_name, device, backend
+            )
+        else:
+            real_dtype = {
+                "complex64": "float32",
+                "complex128": "float64",
+            }[dtype_name]
+            re = _sample_random_array(
+                rng, dist, shape, real_dtype, device, backend
+            )
+            im = _sample_random_array(
+                rng, dist, shape, real_dtype, device, backend
+            )
+            if dist == "normal":
+                re = re / math.sqrt(2)
+                im = im / math.sqrt(2)
+            x = do("complex", re, im, like=backend)
+    else:
+        x = _sample_random_array(rng, dist, shape, dtype_name, device, backend)
+
+    # only compare with the default if it is a scalar, an array is always used
+    if not isinstance(scale, numbers.Number) or scale != 1.0:
+        x = scale * x
+    if not isinstance(loc, numbers.Number) or loc != 0.0:
+        x = loc + x
+    return x
+
+
 # TODO: register other binary functions?
 
 # --------------- object to act as drop-in replace for numpy ---------------- #
@@ -2265,7 +2401,11 @@ class InjectDtypeDevice:
     None, into the kwargs of function `fn`.
     """
 
-    __slots__ = ("_fn", "_device", "_dtype")
+    __slots__ = (
+        "_device",
+        "_dtype",
+        "_fn",
+    )
 
     def __init__(self, fn, device=None, dtype=None):
         self._fn = fn
@@ -2607,16 +2747,48 @@ def jax_from_numpy(x, dtype=None, device=None):
     return jax.numpy.asarray(x, dtype=dtype, device=device)
 
 
+@functools.cache
+def _warn_jax_generated_seed():
+    """Warn one time only, since the message applies to every seedless call."""
+    import warnings
+
+    warnings.warn(
+        "JAX has no shared random state, so random.default_rng(None) "
+        "generates a seed. Inside jax.jit that happens one time, while the "
+        "function is compiled, and every call then reuses the same seed. "
+        "Pass a seed or key into the compiled function instead.",
+        RuntimeWarning,
+    )
+
+
 class JaxDefaultRNG:
     """Stateful but deterministic random number generator for JAX following
-    numpy's Generator API, compatible with `jax.jit`.
+    numpy's Generator API.
+
+    Create this generator inside a ``jax.jit`` function from a seed or key
+    passed to that function. A compiled function that captures a generator
+    created outside it reuses the same values. Later use of that generator can
+    also fail. ``seed=None`` warns one time, because compilation chooses the
+    generated seed once.
     """
 
-    def __init__(self, seed, **kwargs):
+    def __init__(self, seed=None, **kwargs):
         jax = get_jax()
 
         self.jax = jax
+        if seed is None:
+            from random import SystemRandom
+
+            _warn_jax_generated_seed()
+            seed = SystemRandom().randint(-(2**63), 2**63 - 1)
         self.key = jax.random.key(seed, **kwargs)
+
+    @classmethod
+    def from_key(cls, key):
+        rng = object.__new__(cls)
+        rng.jax = get_jax()
+        rng.key = key
+        return rng
 
     def binomial(self, n, p, size=None, **kwargs):
         self.key, subkey = self.jax.random.split(self.key)
@@ -2702,9 +2874,20 @@ class JaxDefaultRNG:
 
 
 @register_function("jax", "random.default_rng")
-def jax_default_rng(seed, **kwargs):
+def jax_default_rng(seed=None, **kwargs):
     if isinstance(seed, JaxDefaultRNG):
         return seed
+
+    jax = get_jax()
+    if isinstance(seed, jax.Array):
+        # only a key has key data, this also accepts the old raw uint32 form
+        try:
+            jax.random.key_data(seed)
+        except TypeError:
+            pass
+        else:
+            return JaxDefaultRNG.from_key(seed)
+
     return JaxDefaultRNG(seed, **kwargs)
 
 
@@ -2722,7 +2905,6 @@ def jax_random_seed(seed=None):
 
 
 def _get_jax_default_rng():
-    global _JAX_DEFAULT_RNG
     if _JAX_DEFAULT_RNG is None:
         jax_random_seed()
     return _JAX_DEFAULT_RNG
@@ -3072,10 +3254,15 @@ class TensorflowDefaultRNG:
 
 
 @register_function("tensorflow", "random.default_rng")
-def tensorflow_default_rng(seed, **kwargs):
+def tensorflow_default_rng(seed=None, **kwargs):
     if isinstance(seed, TensorflowDefaultRNG):
         return seed
     return TensorflowDefaultRNG(seed, **kwargs)
+
+
+register_function(
+    "tensorflow", "random.seed", module="tensorflow.random", alias="set_seed"
+)
 
 
 register_backend(TensorflowDefaultRNG, "tensorflow")
@@ -3337,7 +3524,25 @@ def torch_nonzero_wrap(torch_nonzero):
 class TorchDefaultRNG:
     def __init__(self, seed=None, device=None, dtype=None):
         self._torch = get_torch()
-        self._generator = self._torch.Generator(device=device)
+        if isinstance(seed, self._torch.Generator):
+            # a torch generator cannot be moved, so it must already match
+            if device is not None:
+                device = self._torch.device(device)
+                # an index of None means 'any', which torch accepts either way
+                if (device.type != seed.device.type) or (
+                    (device.index is not None)
+                    and (seed.device.index is not None)
+                    and (device.index != seed.device.index)
+                ):
+                    raise ValueError(
+                        f"The supplied generator is on device {seed.device}, "
+                        f"but device {device} was requested. torch requires "
+                        "the generator and the output to be on the same "
+                        "device."
+                    )
+            self._generator = seed
+        else:
+            self._generator = self._torch.Generator(device=device)
 
         if isinstance(dtype, str):
             dtype = to_backend_dtype(dtype, like="torch")
@@ -3346,7 +3551,7 @@ class TorchDefaultRNG:
         else:
             self._dtype = None
 
-        if seed is not None:
+        if (seed is not None) and not isinstance(seed, self._torch.Generator):
             self._generator.manual_seed(seed)
 
     def _set_default_dtype(self, kwargs):
@@ -3474,26 +3679,51 @@ def torch_default_rng(seed=None, **kwargs):
     return TorchDefaultRNG(seed, **kwargs)
 
 
+@register_function("torch", "random.seed")
+def torch_random_seed(seed=None):
+    torch = get_torch()
+    if seed is None:
+        # torch.random.seed does this, but does not accept a seed itself
+        torch.random.seed()
+    else:
+        torch.manual_seed(seed)
+
+
 register_backend(TorchDefaultRNG, "torch")
 
 register_function("torch", "linalg.expm", module="torch", alias="matrix_exp")
 register_function(
     "torch", "scipy.linalg.expm", module="torch", alias="matrix_exp"
 )
-register_function(
-    "torch",
-    "random.normal",
-    module="torch",
-    alias="randn",
-    wrapper=scale_random_normal_manually,
-)
-register_function(
-    "torch",
-    "random.uniform",
-    module="torch",
-    alias="rand",
-    wrapper=scale_random_uniform_manually,
-)
+
+
+@register_function("torch", "random.normal")
+def torch_random_normal(loc=0.0, scale=1.0, size=None, dtype=None, **kwargs):
+    torch = get_torch()
+    if isinstance(dtype, str):
+        dtype = to_backend_dtype(dtype, like="torch")
+    if dtype is not None:
+        # sample at this dtype directly, not by casting a real draw
+        kwargs["dtype"] = dtype
+    x = torch.randn(_handle_size_to_shape(size), **kwargs)
+    if (loc != 0.0) or (scale != 1.0):
+        x = scale * x + loc
+    return x
+
+
+@register_function("torch", "random.uniform")
+def torch_random_uniform(low=0.0, high=1.0, size=None, dtype=None, **kwargs):
+    torch = get_torch()
+    if isinstance(dtype, str):
+        dtype = to_backend_dtype(dtype, like="torch")
+    if dtype is not None:
+        # as above, e.g. a complex dtype fills the complex unit square
+        kwargs["dtype"] = dtype
+    x = torch.rand(_handle_size_to_shape(size), **kwargs)
+    if (low != 0.0) or (high != 1.0):
+        x = (high - low) * x + low
+    return x
+
 
 register_function("torch", "array", alias="tensor")
 register_function("torch", "asarray", alias="as_tensor")
@@ -3650,7 +3880,7 @@ def torch_copy(x):
 @register_function("torch", "transpose")
 def torch_transpose(x, axes=None):
     if axes is None:
-        axes = reversed(range(0, x.dim()))
+        axes = reversed(range(x.dim()))
     return x.permute(*axes)
 
 
@@ -4056,9 +4286,13 @@ class MlxDefaultRNG:
     numpy's Generator API.
     """
 
-    def __init__(self, seed, **kwargs):
+    def __init__(self, seed=None, **kwargs):
         mx = get_mlx()
         self.mx = mx
+        if seed is None:
+            from random import SystemRandom
+
+            seed = SystemRandom().randint(0, 2**31 - 1)
         self.key = mx.random.key(seed, **kwargs)
 
     # TODO: implement binomial, choice, exponential, poisson when mlx adds them
@@ -4130,7 +4364,7 @@ class MlxDefaultRNG:
 
 
 @register_function("mlx", "random.default_rng")
-def mlx_default_rng(seed, **kwargs):
+def mlx_default_rng(seed=None, **kwargs):
     if isinstance(seed, MlxDefaultRNG):
         return seed
     return MlxDefaultRNG(seed, **kwargs)
@@ -4139,36 +4373,48 @@ def mlx_default_rng(seed, **kwargs):
 register_backend(MlxDefaultRNG, "mlx")
 
 
-_MLX_DEFAULT_RNG = None
+class MlxSharedRNG(MlxDefaultRNG):
+    """Draws from mlx's own shared random state, which ``mx.random.seed``
+    sets, rather than from a key of its own.
+    """
+
+    def __init__(self):
+        self.mx = get_mlx()
+
+    def _split_key(self):
+        # a key of None makes mlx use its shared state
+        return None
+
+
+register_backend(MlxSharedRNG, "mlx")
+
+
+@functools.cache
+def _get_mlx_shared_rng():
+    return MlxSharedRNG()
 
 
 @register_function("mlx", "random.seed")
 def mlx_random_seed(seed=None):
-    global _MLX_DEFAULT_RNG
+    mx = get_mlx()
     if seed is None:
+        # mx.random.seed requires an integer
         from random import SystemRandom
 
         seed = SystemRandom().randint(0, 2**31 - 1)
-    _MLX_DEFAULT_RNG = MlxDefaultRNG(seed)
-
-
-def _get_mlx_default_rng():
-    global _MLX_DEFAULT_RNG
-    if _MLX_DEFAULT_RNG is None:
-        mlx_random_seed()
-    return _MLX_DEFAULT_RNG
+    mx.random.seed(seed)
 
 
 @register_function("mlx", "random.uniform")
 def mlx_random_uniform(low=0.0, high=1.0, size=None, **kwargs):
-    return _get_mlx_default_rng().uniform(
+    return _get_mlx_shared_rng().uniform(
         low=low, high=high, size=size, **kwargs
     )
 
 
 @register_function("mlx", "random.normal")
 def mlx_random_normal(loc=0.0, scale=1.0, size=None, **kwargs):
-    return _get_mlx_default_rng().normal(
+    return _get_mlx_shared_rng().normal(
         loc=loc, scale=scale, size=size, **kwargs
     )
 

--- a/autoray/autoray.py
+++ b/autoray/autoray.py
@@ -673,7 +673,7 @@ _FUNC_ALIASES = {}
 #     name. For example, when kwargs need to be translated or results modified
 _CUSTOM_WRAPPERS = {}
 
-# actual cache of funtions to use - this is populated lazily and can be used
+# actual cache of functions to use - this is populated lazily and can be used
 #     to directly set an implementation of a function for a specific backend
 _FUNCS = {}
 
@@ -761,7 +761,7 @@ def import_lib_fn(backend, fn):
 
 def get_lib_fn(backend, fn):
     """Cached retrieval of correct function for backend, all the logic for
-    finding the correct funtion only runs the first time.
+    finding the correct function only runs the first time.
 
     Parameters
     ----------
@@ -986,6 +986,8 @@ def register_function(
     _NAMESPACE_CACHE.clear()
     # the dtype cache also keeps results from ``get_lib_fn``
     _to_backend_dtype_from_str_cached.cache_clear()
+    # this holds arrays built with ``array`` and ``astype``
+    _get_rademacher_table.cache_clear()
 
     if fn is None:
         if wrapper is True:
@@ -1444,7 +1446,7 @@ class Composed:
         return f"Composed('{self._name}')"
 
 
-def compose(fn, *, name=None):
+def compose(fn=None, *, name=None):
     """Take a function consisting of multiple ``autoray.do`` calls and compose
     it into a new, single, named function, registered with ``autoray.do``.
 
@@ -1467,10 +1469,19 @@ def compose(fn, *, name=None):
         def foo_numba(x):
             ...
 
+    Supply ``name`` to register the function under a name other than its own,
+    which requires calling ``compose`` first::
+
+        @compose(name="linalg.qr")
+        def qr(x):
+            ...
+
     Parameters
     ----------
-    fn : callable
-        The funtion to compose, and its default implementation.
+    fn : callable, optional
+        The function to compose, and its default implementation. Omitting it
+        returns a decorator that takes it, which is how the second form above
+        supplies ``name``.
     name : str, optional
         The name of the composed function. If not provided, the name of the
         function will be used.
@@ -2268,7 +2279,63 @@ def random_array_dispatcher(shape, rng=None, **kwargs):
 register_dispatch("random.array", random_array_dispatcher)
 
 
-_RANDOM_DISTS = ("normal", "uniform")
+_RANDOM_DISTS = ("normal", "uniform", "rademacher")
+
+
+_COMPLEX_TO_REAL_DTYPE = {
+    "complex64": "float32",
+    "complex128": "float64",
+}
+
+_RADEMACHER_SIGNS = (-1.0, 1.0)
+
+# four roots of unity, the complex analogue of {-1, +1}
+_RADEMACHER_ROOTS = (1.0 + 0.0j, 0.0 + 1.0j, -1.0 + 0.0j, -0.0 - 1.0j)
+
+# faster per backend implementations of _sample_rademacher
+_RADEMACHER_SAMPLERS = {}
+
+# those of the above that also accept rng=None, the rest need a generator,
+# since only these reach integers through the shared random state
+_RADEMACHER_SHARED = set()
+
+
+@functools.lru_cache(None)
+def _get_rademacher_table(dtype_name, backend):
+    """The lookup table to index for a rademacher sample: the two signs, or
+    the four roots of unity for a complex ``dtype_name``.
+    """
+    if dtype_name in _COMPLEX_TO_REAL_DTYPE:
+        values = _RADEMACHER_ROOTS
+    else:
+        values = _RADEMACHER_SIGNS
+    return astype(do("array", values, like=backend), dtype_name)
+
+
+def _sample_rademacher(rng, shape, dtype_name, device, backend):
+    """Draw from ``{-1, +1}``, or from the four roots of unity for a complex
+    ``dtype_name``. Both have modulus one and mean zero.
+    """
+    if (rng is not None) or (backend in _RADEMACHER_SHARED):
+        fast = _RADEMACHER_SAMPLERS.get(backend)
+        if fast is not None:
+            return fast(rng, shape, dtype_name, device)
+
+    if dtype_name in _COMPLEX_TO_REAL_DTYPE:
+        # draw a sign, then which component carries it
+        real_dtype = _COMPLEX_TO_REAL_DTYPE[dtype_name]
+        s = _sample_rademacher(rng, shape, real_dtype, device, backend)
+        m = _sample_random_array(
+            rng, "uniform", shape, real_dtype, device, backend
+        )
+        re = s * astype(m < 0.5, real_dtype)
+        return do("complex", re, s - re, like=backend)
+
+    # nothing above applies, so map a uniform sample onto {-1, +1}
+    u = _sample_random_array(
+        rng, "uniform", shape, dtype_name, device, backend
+    )
+    return 1.0 - 2.0 * astype(u < 0.5, dtype_name)
 
 
 def _sample_random_array(rng, dist, shape, dtype_name, device, backend):
@@ -2294,11 +2361,13 @@ def _sample_random_array(rng, dist, shape, dtype_name, device, backend):
     if get_dtype_name(x) != dtype_name:
         x = astype(x, dtype_name)
     if (device is not None) and (backend != "torch"):
+        # only torch takes a device, so the rest generate on the default
+        # device and possibly move the samples after
         x = to_device(x, device)
     return x
 
 
-@functools.partial(compose, name="random.array")
+@compose(name="random.array")
 def random_array(
     shape,
     dist="normal",
@@ -2315,8 +2384,10 @@ def random_array(
     ----------
     shape : tuple[int]
         Shape of the generated array.
-    dist : {"normal", "uniform"}, optional
+    dist : {"normal", "uniform", "rademacher"}, optional
         Distribution to sample before applying ``loc`` and ``scale``.
+        ``"rademacher"`` draws each entry from ``{-1, +1}``, or from the four
+        roots of unity for a complex ``dtype``, with equal probability.
     loc : float or complex, optional
         Location applied after sampling.
     scale : float or complex, optional
@@ -2338,8 +2409,9 @@ def random_array(
     -------
     array
         Random samples with ``x = loc + scale * z``. Before this transform, a
-        complex normal ``z`` has total variance one, and a complex uniform
-        ``z`` fills the unit square.
+        complex normal or rademacher ``z`` has total variance one, and a
+        complex uniform ``z`` fills the unit square. A rademacher ``z`` has
+        modulus exactly one.
     """
     if dist not in _RANDOM_DISTS:
         raise ValueError(
@@ -2359,17 +2431,16 @@ def random_array(
         # jax has no shared random state, so use the module level generator
         rng = _get_jax_default_rng()
 
-    if dtype_name in _COMPLEX_DTYPES:
+    if dist == "rademacher":
+        x = _sample_rademacher(rng, shape, dtype_name, device, backend)
+    elif dtype_name in _COMPLEX_DTYPES:
         if (dist == "normal") and (backend in ("jax", "torch")):
             # can sample complex normal directly
             x = _sample_random_array(
                 rng, dist, shape, dtype_name, device, backend
             )
         else:
-            real_dtype = {
-                "complex64": "float32",
-                "complex128": "float64",
-            }[dtype_name]
+            real_dtype = _COMPLEX_TO_REAL_DTYPE[dtype_name]
             re = _sample_random_array(
                 rng, dist, shape, real_dtype, device, backend
             )
@@ -2633,6 +2704,28 @@ register_function("numpy", "random.uniform", wrapper=with_dtype_wrapper)
 
 register_function("numpy", "complex", complex_add_re_im)
 
+
+def _rademacher_numpy(rng, shape, dtype_name, device):
+    # int8 is the narrowest draw numpy offers, and enough for one or two bits
+    complex_dtype = dtype_name in _COMPLEX_TO_REAL_DTYPE
+    high = 4 if complex_dtype else 2
+    if rng is None:
+        # the legacy global functions are numpy's shared random state, and
+        # randint takes a dtype, unlike uniform which is float64 only
+        import numpy
+
+        k = numpy.random.randint(0, high, size=shape, dtype="int8")
+    else:
+        k = rng.integers(0, high, size=shape, dtype="int8")
+
+    if complex_dtype:
+        return _get_rademacher_table(dtype_name, "numpy")[k]
+    return (2 * k - 1).astype(dtype_name)
+
+
+_RADEMACHER_SAMPLERS["numpy"] = _rademacher_numpy
+_RADEMACHER_SHARED.add("numpy")
+
 # ---------------------------------- cupy ----------------------------------- #
 
 
@@ -2691,6 +2784,28 @@ def cupy_from_numpy(x, dtype=None, device=None):  # pragma: no cover
 
     with cupy.cuda.Device(device):
         return cupy.asarray(x, dtype=dtype)
+
+
+def _rademacher_cupy(rng, shape, dtype_name, device):  # pragma: no cover
+    # int8 is both the cheapest draw and the fastest index here
+    table = _get_rademacher_table(dtype_name, "cupy")
+    if rng is None:
+        import cupy
+
+        k = cupy.random.randint(0, len(table), size=shape, dtype="int8")
+    else:
+        k = rng.integers(0, len(table), size=shape, dtype="int8")
+    # the cached table may have been built on another device
+    x = to_device(table, k.device)[k]
+    if device is not None:
+        # the generator has its own device, so this generates there and
+        # possibly moves the samples after
+        x = to_device(x, device)
+    return x
+
+
+_RADEMACHER_SAMPLERS["cupy"] = _rademacher_cupy
+_RADEMACHER_SHARED.add("cupy")
 
 
 register_module_alias("cupy.scipy", "cupyx.scipy")
@@ -2922,6 +3037,25 @@ def jax_random_normal(loc=0.0, scale=1.0, size=None, **kwargs):
     return _get_jax_default_rng().normal(
         loc=loc, scale=scale, size=size, **kwargs
     )
+
+
+def _rademacher_jax(rng, shape, dtype_name, device):
+    rng.key, subkey = rng.jax.random.split(rng.key)
+    if dtype_name in _COMPLEX_TO_REAL_DTYPE:
+        # take the two lowest bits, cheaper than randint
+        roots = _get_rademacher_table(dtype_name, "jax")
+        bits = rng.jax.random.bits(subkey, shape, dtype="uint8")
+        x = roots[bits & 3]
+    else:
+        x = rng.jax.random.rademacher(subkey, shape, dtype=dtype_name)
+    if device is not None:
+        # jax.random takes no device, so this generates on the default device
+        # and possibly moves the samples after
+        x = to_device(x, device)
+    return x
+
+
+_RADEMACHER_SAMPLERS["jax"] = _rademacher_jax
 
 
 register_backend_alias("jaxlib", "jax")
@@ -3687,6 +3821,43 @@ def torch_random_seed(seed=None):
         torch.random.seed()
     else:
         torch.manual_seed(seed)
+
+
+def _rademacher_torch(rng, shape, dtype_name, device):
+    # a generator of None means torch's shared random state
+    torch = get_torch() if rng is None else rng._torch
+    generator = None if rng is None else rng._generator
+    real_dtype = _COMPLEX_TO_REAL_DTYPE.get(dtype_name, dtype_name)
+    kwargs = {"dtype": to_backend_dtype(real_dtype, "torch")}
+    if device is not None:
+        kwargs["device"] = torch.device(device)
+    elif rng is not None:
+        rng._set_default_device(kwargs)
+    else:
+        kwargs["device"] = torch.get_default_device()
+
+    if dtype_name in _COMPLEX_TO_REAL_DTYPE:
+        roots = _get_rademacher_table(dtype_name, "torch")
+        if kwargs["device"].type == "cpu":
+            # on cpu torch.randint costs the same at every width, and about
+            # twice a float sample, so take the two bits from one of those
+            u = torch.rand(shape, generator=generator, **kwargs)
+            k = (u * 4.0).long()
+        else:
+            # elsewhere it is the cheaper source, and narrower than int64
+            # only makes the indexing slower
+            k = torch.randint(
+                0, 4, shape, generator=generator, device=kwargs["device"]
+            )
+        return roots.to(kwargs["device"])[k]
+
+    u = torch.rand(shape, generator=generator, **kwargs)
+    one = torch.ones((), **kwargs)
+    return torch.where(u < 0.5, -one, one)
+
+
+_RADEMACHER_SAMPLERS["torch"] = _rademacher_torch
+_RADEMACHER_SHARED.add("torch")
 
 
 register_backend(TorchDefaultRNG, "torch")

--- a/docs/automatic_dispatch.md
+++ b/docs/automatic_dispatch.md
@@ -69,6 +69,13 @@ overrides method 1. above but 2. and 3. still take precedence. The argument to
 array.
 
 
+```{hint}
+Random number generation diverges enough between backends to have its own
+guide - see [](random.md) for [`do`](autoray.do)'s unified generators and the
+``"random.array"`` creation routine.
+```
+
+
 ## Namespace API
 
 An alternative way to call functions is to get a namespace object using

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,21 @@
 
 Release notes for `autoray`.
 
+## v0.10.0 (unreleased)
+
+**Enhancements:**
+
+- Added ``do("random.array", ...)`` for backend-agnostic normal and uniform random arrays. It accepts backend-specific generators or seeds, inherits dtype and device from ``like``, and generates complex normal samples with unit total variance. JAX ``random.default_rng(None)`` warns one time, because tracing fixes its generated seed.
+- `jax`, `mlx` and `tensorflow` `"random.default_rng"` now default to `seed=None`, and `jax` also accepts a key. `torch` `"random.default_rng"` accepts a `torch.Generator`, and raises a descriptive error if a device is also requested that the generator cannot supply.
+- Added a [random numbers](random.md) documentation guide, covering `"random.array"`, the generator objects and their per backend method coverage, the shared random state, the complex normal convention, and the rules for `jax.jit` and `torch.compile`.
+
+**Bug Fixes:**
+
+- `torch` `"random.normal"` and `"random.uniform"` now generate at the requested `dtype` rather than casting afterwards. A complex `dtype` therefore gets a complex sample rather than a real one cast up, which previously left the imaginary part zero, and `float64` now carries full double precision entropy.
+- `torch` `"random.seed"` is now registered, and seeds the shared random state. Previously it resolved to `torch.random.seed`, which takes no seed and thus raised `TypeError`.
+- `tensorflow` `"random.seed"` is now registered, as an alias of `tf.random.set_seed`. Previously it raised `ImportError`.
+- `mlx` now uses mlx's own shared random state, rather than a separate module level generator of autoray's. `do("random.seed", seed, like="mlx")` therefore reaches `mx.random.seed`, and mixing autoray and raw `mlx.core.random` calls is now reproducible in both directions.
+
 ## v0.9.1 (2026-08-03)
 
 **Bug Fixes:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,9 +6,9 @@ Release notes for `autoray`.
 
 **Enhancements:**
 
-- Added ``do("random.array", ...)`` for backend-agnostic normal and uniform random arrays. It accepts backend-specific generators or seeds, inherits dtype and device from ``like``, and generates complex normal samples with unit total variance. JAX ``random.default_rng(None)`` warns one time, because tracing fixes its generated seed.
+- Added [`random_array`](autoray.autoray.random_array), i.e. `do("random.array", ...)`, for backend-agnostic normal, uniform and rademacher random arrays. It accepts backend-specific generators or seeds, inherits dtype and device from `like`, and generates complex normal samples with unit total variance. A complex rademacher sample is a choice from the four roots of unity, so it also has modulus one. `jax` `"random.default_rng"` with `seed=None` warns one time, because tracing fixes its generated seed.
 - `jax`, `mlx` and `tensorflow` `"random.default_rng"` now default to `seed=None`, and `jax` also accepts a key. `torch` `"random.default_rng"` accepts a `torch.Generator`, and raises a descriptive error if a device is also requested that the generator cannot supply.
-- Added a [random numbers](random.md) documentation guide, covering `"random.array"`, the generator objects and their per backend method coverage, the shared random state, the complex normal convention, and the rules for `jax.jit` and `torch.compile`.
+- Added a [random numbers](random.md) documentation guide, covering [`random_array`](autoray.autoray.random_array), the generator objects and their per backend method coverage, the shared random state, the complex normal convention, and the rules for `jax.jit` and `torch.compile`.
 
 **Bug Fixes:**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,15 @@ autosectionlabel_prefix_document = True
 
 # sphinx-autoapi
 autoapi_dirs = ["../autoray"]
+# these are the defaults apart from 'imported-members' is removed
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "private-members",
+    "show-inheritance",
+    "show-module-summary",
+    "special-members",
+]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -135,6 +135,24 @@ On ReadTheDocs, the build is driven by `.readthedocs.yml` and uses the
 dedicated `readthedocs` pixi task.
 
 
+### Referencing functions and methods
+
+The API docs are generated with
+[`sphinx-autoapi`](https://sphinx-autoapi.readthedocs.io/en/latest/), which
+documents each object only where it is *defined*, not where it is re-exported.
+References should either use the full path or a short suffix-matching form:
+
+- In MyST markdown, use a link with a leading `#`: `` [`do`](#do) ``,
+  `` [`LazyArray.ascend`](#LazyArray.ascend) ``. This is the preferred form,
+  since it also renders cleanly as plain markdown.
+- In a docutils role, use a leading `.`: `` {func}`.do` ``,
+  `` {meth}`.LazyArray.ascend` ``. Roles are typed, so prefer them in
+  docstrings and to disambiguate a name that matches more than one object.
+
+Keep enough trailing components to be unambiguous. If a bare name still
+matches several objects, qualify it further or give an explicit title.
+
+
 ## Minting a release
 
 `autoray` uses

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ Beyond that, abstracting the array interface allows you to:
 
 * *swap [custom versions of functions](automatic_dispatch.md#functions)
   for specific backends*
+* *generate [random numbers](random.md) with a single interface to every
+  backend's generators and state*
 * *trace through computations [lazily](lazy_computation) without actually
   running them*
 * *automatically [share intermediates and fold constants](lazy_computation)
@@ -110,6 +112,7 @@ Custom backends and functions can be dynamically registered with:
 
 installation.md
 automatic_dispatch.md
+random.md
 lazy_computation.ipynb
 compilation.ipynb
 ```

--- a/docs/lazy_computation.ipynb
+++ b/docs/lazy_computation.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "source": [
     "If instead we wanted to run the function lazily, we first call\n",
-    "[`lazy.array`](autoray.lazy.array) to wrap `x`:"
+    "[`lazy.array`](#array) to wrap `x`:"
    ]
   },
   {
@@ -134,7 +134,7 @@
    "id": "03d992ad-f746-4cc2-9e56-14606bc827a3",
    "metadata": {},
    "source": [
-    "[`LazyArray`](autoray.lazy.LazyArray) objects simply stores the following:\n",
+    "[`LazyArray`](#LazyArray) objects simply stores the following:\n",
     "\n",
     "* The function to be called and backend it came from\n",
     "* The `args` and `kwargs` to be passed to the function\n",
@@ -161,12 +161,12 @@
     "'children'). However from this we can still traverse the nodes and extract an\n",
     "actual graph if so desired. Useful methods are:\n",
     "\n",
-    "* [`LazyArray.ascend`](autoray.lazy.ascend) - generate every unique node\n",
+    "* [`LazyArray.ascend`](#core.ascend) - generate every unique node\n",
     "  in the graph, yielding dependencies before their children (i.e. a topological\n",
     "  sort). This is the computational order. Nodes are also sorted by their\n",
     "  *'depth'*, i.e. the longest distance to an input.\n",
     "\n",
-    "* [`LazyArray.descend`](autoray.lazy.descend) - generate every unique node\n",
+    "* [`LazyArray.descend`](#core.descend) - generate every unique node\n",
     "  in the graph, starting from the current node. Use this if order doesn't\n",
     "  matter.\n",
     "\n",
@@ -177,7 +177,7 @@
     "\n",
     "You can also extract an actual graph using the following method:\n",
     "\n",
-    "- [`LazyArray.to_nx_digraph`](autoray.lazy.LazyArray.to_nx_digraph)\n",
+    "- [`LazyArray.to_nx_digraph`](#LazyArray.to_nx_digraph)\n",
     "\n",
     "\n",
     "Some built in graph inspection methods are illustrated below:"
@@ -512,7 +512,7 @@
     "## Computation\n",
     "\n",
     "When you are ready to actually perform the computation, you can call\n",
-    "[`LazyArray.compute`](autoray.lazy.LazyArray.compute) on output nodes:"
+    "[`LazyArray.compute`](#LazyArray.compute) on output nodes:"
    ]
   },
   {
@@ -548,13 +548,13 @@
    "metadata": {},
    "source": [
     "```{note}\n",
-    "[`LazyArray`](autoray.lazy.LazyArray) objects clear references to their\n",
+    "[`LazyArray`](#LazyArray) objects clear references to their\n",
     "dependencies once computed and simply store the result and shape. This is to\n",
     "aid garbage collection and reduce memory usage.\n",
     "```\n",
     "\n",
     "The computation is done non-recursively. You can compute multiple outputs at\n",
-    "once with the function [`lazy.compute`](autoray.lazy.compute):"
+    "once with the function [`lazy.compute`](#core.compute):"
    ]
   },
   {
@@ -588,10 +588,10 @@
     "### Sharing intermediates\n",
     "\n",
     "A basic computational graph optimization that `autoray` can do is to\n",
-    "automatically cache [`LazyArray`](autoray.lazy.LazyArray) objects that are\n",
+    "automatically cache [`LazyArray`](#LazyArray) objects that are\n",
     "computed with the same inputs. This is achieved with the context manager:\n",
     "\n",
-    "* [`lazy.shared_intermediates`](autoray.lazy.shared_intermediates)"
+    "* [`lazy.shared_intermediates`](#shared_intermediates)"
    ]
   },
   {
@@ -684,8 +684,8 @@
     "Sometimes you may want to think of certain input nodes as variables, which\n",
     "might change from call to call, and any other inputs as constants. One option\n",
     "is to create 'empty'\n",
-    "[`LazyArray`](autoray.lazy.LazyArray) instances with\n",
-    "[`lazy.Variable`](autoray.lazy.Variable), which just\n",
+    "[`LazyArray`](#LazyArray) instances with\n",
+    "[`lazy.Variable`](#Variable), which just\n",
     "takes a shape and optionally backend, and uses a placeholder for the data."
    ]
   },
@@ -791,7 +791,7 @@
    "source": [
     "If one wants to extract the function that the computational graph represents,\n",
     "in order to call it repeatedly with different inputs, then one can create a\n",
-    "[`lazy.Function`](autoray.lazy.Function):"
+    "[`lazy.Function`](#Function):"
    ]
   },
   {
@@ -823,7 +823,7 @@
    "metadata": {},
    "source": [
     "```{hint}\n",
-    "By default, [`lazy.Function`](autoray.lazy.Function) will compute constants,\n",
+    "By default, [`lazy.Function`](#Function) will compute constants,\n",
     "as we did above, this can be disabled by passing `fold_constants=False`.\n",
     "```"
    ]
@@ -872,14 +872,14 @@
    "source": [
     "```{note}\n",
     "Such a function is created with the backend specific functions injected in, see\n",
-    "[the compilation](compilation) section and [`autojit`](autoray.autojit) for\n",
+    "[the compilation](compilation) section and [`autojit`](#autojit) for\n",
     "creating such functions just in time for the right backend.\n",
     "```\n",
     "\n",
     "You can view the function's source code using\n",
-    "[Function.print_source](autoray.lazy.Function.print_source), or extract it\n",
-    "from [`LazyArray`](autoray.lazy.LazyArray) objects yourself with\n",
-    "[lazy.get_source](autoray.lazy.get_source)."
+    "[Function.print_source](#Function.print_source), or extract it\n",
+    "from [`LazyArray`](#LazyArray) objects yourself with\n",
+    "[lazy.get_source](#core.get_source)."
    ]
   },
   {
@@ -1149,7 +1149,7 @@
    "metadata": {},
    "source": [
     "Hopefully `aesara` will be another possible target for\n",
-    "[`autoray.autojit`](autoray.autojit), eventually."
+    "[`autoray.autojit`](#autojit), eventually."
    ]
   }
  ],

--- a/docs/random.md
+++ b/docs/random.md
@@ -53,6 +53,10 @@ The sampled value `z` is set by `dist`:
 
 * `dist="normal"` draws a normal sample with mean zero and variance one.
 * `dist="uniform"` draws a sample from `[0, 1)`.
+* `dist="rademacher"` draws `-1` or `+1` with equal probability, giving mean
+  zero and variance one like `"normal"`, but with every entry the same
+  magnitude. This is the usual choice for a Hutchinson trace estimator, where
+  it has the lower variance of the two.
 
 If `loc` and `scale` are provided, the final values are transformed as
 `scale * z + loc`. Either can be an array, which broadcasts against the
@@ -108,7 +112,9 @@ ar.do("random.normal", size=(3,), dtype="complex128", like="numpy")
 ````
 
 A complex `"uniform"` sample fills the complex unit square, i.e. the real and
-imaginary parts are each drawn from `[0, 1)`.
+imaginary parts are each drawn from `[0, 1)`. A complex `"rademacher"` sample
+is a choice from the four roots of unity $\{1, i, -1, -i\}$, which likewise
+satisfy $\mathbb{E}[|z|^2] = 1$ and $\mathbb{E}[z z^\dagger] = I$.
 
 
 ## Controlling the state with `rng`
@@ -158,6 +164,10 @@ the generator and the output to share a device. Requesting a `device` that the
 supplied generator cannot serve raises a descriptive `ValueError` rather than
 a torch internal error.
 ```
+
+Of the backends here only torch generates directly on a requested `device`. The
+rest take no device at all, so `"random.array"` generates on their default
+device and moves the result, meaning a `device` that differs costs a copy.
 
 
 ## Generator objects

--- a/docs/random.md
+++ b/docs/random.md
@@ -1,0 +1,278 @@
+# Random numbers
+
+Random number generation is one of the areas where array backends diverge most:
+the function names differ, the state handling differs, and not every library
+has a shared global state at all. [`autoray`](autoray) provides a unified
+interface at three different levels:
+
+* [`do("random.array", ...)`](autoray.autoray.random_array) - a single
+  *unified* backend agnostic creation routine, recommended for most use cases.
+  It supports `dtype` and `device` matching, distribution as a parameter,
+  consistent handling of complex dtypes, `loc` and `scale`, and both implicit
+  and explicit random state.
+
+* `do("random.default_rng", seed, like=...)` - an *explicit* generator object
+  with a `numpy.random.Generator`-like API, supporting many distributions.
+
+* `do("random.normal", ...)` and friends - the backend's *shared* random
+  state, seeded with `do("random.seed", seed, like=...)`.
+
+
+## Generating an array
+
+[`"random.array"`](autoray.autoray.random_array) is the recommended entry
+point. It is a creation routine, so it takes the shape first and picks up
+`dtype` and `device` from `like`:
+
+```python
+import autoray as ar
+
+x = ar.do("random.array", (2, 3), like="torch")
+
+# match the backend, dtype and device of an existing array
+y = ar.do("random.array", ar.shape(x), like=x)
+```
+
+The full signature is:
+
+```python
+ar.do(
+    "random.array",
+    shape,
+    dist="normal",
+    loc=0.0,
+    scale=1.0,
+    dtype=None,
+    device=None,
+    rng=None,
+    like=None,
+)
+```
+
+The sampled value `z` is set by `dist`:
+
+* `dist="normal"` draws a normal sample with mean zero and variance one.
+* `dist="uniform"` draws a sample from `[0, 1)`.
+
+If `loc` and `scale` are provided, the final values are transformed as
+`scale * z + loc`. Either can be an array, which broadcasts against the
+generated samples.
+
+```{note}
+`loc` and `scale` shift and scale the *whole* sample, so for `"uniform"` they
+describe an interval of width `scale` starting at `loc`, rather than the
+`low` and `high` pair that
+[`numpy.random.Generator.uniform`](numpy.random.Generator.uniform) takes.
+```
+
+Unlike a raw `do("random.normal", ...)` call, `"random.array"` aims to mean the
+same thing across backends: the requested `dtype` is the dtype sampled at,
+complex dtypes are handled explicitly, and the result is generated on the
+requested device.
+
+
+### Complex dtypes
+
+A complex `dtype` is supported directly, and follows the standard convention
+for a *complex normal* `z`, that is,
+
+$$
+\mathbb{E}[z] = 0, \quad \mathbb{E}[|z|^2] = 1,
+$$
+
+with the real and imaginary parts each having variance $1/2$. This makes
+`scale` mean the same thing for real and complex dtypes, and makes
+$\mathbb{E}[z z^\dagger] = I$, as required for e.g. Hutchinson trace
+estimation:
+
+```python
+z = ar.do("random.array", (10000,), dtype="complex128", rng=42, like="numpy")
+
+ar.do("mean", ar.do("abs", z) ** 2)
+# 1.00945...
+```
+
+It is the same convention that `jax` and `torch` use for their own complex
+normals, which `"random.array"` defers to directly. Elsewhere it draws the two
+real parts and scales them by $1/\sqrt{2}$.
+
+````{warning}
+The raw `do("random.normal", ...)` call gives no such guarantee. On a backend
+whose generator has no complex support, a complex `dtype` is applied by casting
+a *real* sample, silently leaving the imaginary part zero:
+
+```python
+ar.do("random.normal", size=(3,), dtype="complex128", like="numpy")
+# array([-0.15591091+0.j, -0.36737385+0.j,  0.55108074+0.j])
+```
+````
+
+A complex `"uniform"` sample fills the complex unit square, i.e. the real and
+imaginary parts are each drawn from `[0, 1)`.
+
+
+## Controlling the state with `rng`
+
+The `rng` argument selects between shared and explicit state, and accepts the
+following forms:
+
+| `rng` | state | behaviour |
+| :--- | :--- | :--- |
+| `None` (default) | shared | use the backend's global random state |
+| `int` | neither | make a fresh generator seeded with this, for this call |
+| a generator | explicit | use and advance that generator's own state |
+| a backend seed object | explicit | whatever that backend's `default_rng` takes |
+
+An integer gives a reproducible array without touching any global state:
+
+```python
+xa = ar.do("random.array", (2, 3), rng=42, like="numpy")
+xb = ar.do("random.array", (2, 3), rng=42, like="numpy")
+ar.do("allclose", xa, xb)
+# True
+```
+
+A generator carries state between calls, so successive draws differ, and it
+also supplies the backend, meaning `like` is not needed:
+
+```python
+rng = ar.do("random.default_rng", 42, like="torch")
+
+x = ar.do("random.array", (2, 3), rng=rng)
+y = ar.do("random.array", (2, 3), rng=rng)  # different values to x
+```
+
+The last row of the table means each backend additionally accepts its own
+native seed and state objects, since `rng` is passed through to that backend's
+`"random.default_rng"`. For instance `numpy` accepts a `SeedSequence` or a
+`BitGenerator`, `jax` accepts a key, and `torch` accepts a `torch.Generator`:
+
+```python
+key = jax.random.key(42)
+x = ar.do("random.array", (2, 3), rng=key, like="jax")
+```
+
+```{note}
+A `torch.Generator` is bound to the device it was made on, and torch requires
+the generator and the output to share a device. Requesting a `device` that the
+supplied generator cannot serve raises a descriptive `ValueError` rather than
+a torch internal error.
+```
+
+
+## Generator objects
+
+`do("random.default_rng", seed, like=...)` returns an object holding explicit
+state, with the [`numpy.random.Generator`](numpy.random.Generator) API, for
+`numpy`, `cupy`, `dask`, `jax`, `mlx`, `tensorflow` and `torch`. For the
+libraries that do not natively provide one, `autoray` supplies a shim class
+implementing the same methods on top of that backend's primitives, so a `jax`
+generator for instance holds and splits a key behind the same interface.
+
+```python
+rng = ar.do("random.default_rng", 42, like="jax")
+
+rng.normal(size=(2, 3))
+rng.integers(0, 10, size=(2, 3))
+rng.choice(ar.do("arange", 10, like=rng), size=5)
+```
+
+In each case `seed` defaults to `None`, meaning non-deterministic
+initialization. The generator itself is a registered `autoray` backend object,
+so it is also accepted anywhere a `like` argument is.
+
+Method coverage depends on what the underlying library exposes:
+
+| method | numpy | cupy | dask | jax | mlx | tensorflow | torch |
+| :--- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| `uniform` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `random` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `integers` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `normal` | ✓ | | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `binomial` | ✓ | ✓ | ✓ | ✓ | | | |
+| `choice` | ✓ | | ✓ | ✓ | | | ✓ |
+| `exponential` | ✓ | ✓ | ✓ | ✓ | | | |
+| `gumbel` | ✓ | | ✓ | ✓ | ✓ | | |
+| `permutation` | ✓ | | ✓ | ✓ | ✓ | | ✓ |
+| `poisson` | ✓ | ✓ | ✓ | ✓ | | | |
+
+A missing entry raises rather than silently doing something else, and the gaps
+are tracked in `tests/conftest.py` so that they close automatically as the
+backends grow the relevant interfaces.
+
+```{hint}
+The gaps do not carry over to `"random.array"`, which works for all the
+backends listed. `cupy` for example has no `normal` method, but does have the
+equivalent `standard_normal`, which `"random.array"` uses instead.
+```
+
+
+## Shared random state
+
+With `rng=None`, `"random.array"` uses the backend's shared state, which is
+seeded through `do("random.seed", seed, like=...)`:
+
+```python
+ar.do("random.seed", 42, like="torch")
+x = ar.do("random.array", (2, 3), like="torch")
+```
+
+This is registered function for the backends above, e.g. for `torch` it
+forwards to `torch.manual_seed`, since `torch.random.seed` takes no seed at
+all, and for `tensorflow` to `tf.random.set_seed`.
+
+`jax` is the exception, having no shared state of its own, since every
+`jax.random` call requires a key. For it `autoray` keeps a module level
+generator and uses that for `rng=None`, so seedless code still works and
+`do("random.seed", ..., like="jax")` still makes it reproducible.
+
+
+## Compiled functions
+
+Random state and tracing interact awkwardly, in opposite ways for the two main
+compilers.
+
+For `jax.jit`, pass a seed or key *into* the function and build the generator
+inside it:
+
+```python
+@jax.jit
+def sample(seed):
+    rng = ar.do("random.default_rng", seed, like="jax")
+    return ar.do("random.array", (2, 3), rng=rng, like="jax")
+```
+
+```{warning}
+Capturing a generator made outside the function, or using `rng=None`, fails
+quietly rather than raising: the key is frozen at trace time, so each call hits
+the trace cache and returns the *same* values. The error comes later, since the
+generator is left holding a tracer, and both eager use of it and any retrace of
+the compiled function then raise `UnexpectedTracerError`. For `rng=None` the
+affected generator is autoray's module level one, which
+`ar.do("random.seed", seed, like="jax")` restores.
+```
+
+For `torch.compile` it is the other way round: use `rng=None`, since the
+compiler handles torch's shared random state itself, whereas an explicit
+`torch.Generator` causes a graph break and so is incompatible with
+`fullgraph=True`.
+
+```python
+@torch.compile(fullgraph=True)
+def sample():
+    return ar.do("random.array", (2, 3), like="torch")
+
+
+# call once eagerly first, so that dynamo does not have to trace the import
+ar.do("random.array", (2, 3), like="torch")
+
+sample()
+```
+
+```{note}
+The warm up call matters: `autoray` imports and caches a backend function the
+first time it is used, and dynamo cannot trace that import machinery. Without
+it, the first compiled call fails with a `torch._dynamo.exc.Unsupported` error.
+This is not specific to the random functions, but applies to the first use of
+an `autoray` function inside a `fullgraph=True` region.
+```

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import pytest
 
 import autoray as ar
@@ -163,7 +165,7 @@ def test_jax_jit_random():
 
 class TestRandomArray:
     @pytest.mark.parametrize("device", ["inherited", "cpu", "cuda"])
-    @pytest.mark.parametrize("dist", ["normal", "uniform"])
+    @pytest.mark.parametrize("dist", ["normal", "uniform", "rademacher"])
     @pytest.mark.parametrize(
         "backend,dtype,fn",
         gen_params(
@@ -237,7 +239,7 @@ class TestRandomArray:
         x = ar.do("to_numpy", x)
         assert (abs(x) ** 2).mean() == pytest.approx(1.0, abs=0.03)
 
-    @pytest.mark.parametrize("dist", ["normal", "uniform"])
+    @pytest.mark.parametrize("dist", ["normal", "uniform", "rademacher"])
     @pytest.mark.parametrize(
         "backend,fn",
         gen_params(
@@ -268,11 +270,36 @@ class TestRandomArray:
             2.0 + 3.0 * ar.do("to_numpy", x)
         )
 
+    # rng=None takes the generic path, an rng the per backend fast one
+    @pytest.mark.parametrize("rng", [42, None])
+    @pytest.mark.parametrize(
+        "backend,dtype,fn",
+        gen_params(
+            backends=_RANDOM_BACKENDS,
+            dtypes=...,
+            fns=["random.array"],
+        ),
+    )
+    def test_rademacher_values(self, backend, dtype, fn, rng):
+        n = 20_000
+        x = ar.do(
+            fn, (n,), dist="rademacher", dtype=dtype, rng=rng, like=backend
+        )
+        assert ar.get_dtype_name(x) == dtype
+        x = ar.do("to_numpy", x)
+        assert abs(x) == pytest.approx(1.0)
+
+        # both signs appear, and all four roots of unity for a complex dtype
+        counts = Counter(x.tolist())
+        assert len(counts) == (4 if "complex" in dtype else 2)
+        # each is equally likely, well within 5 sigma at this size
+        expected = n / len(counts)
+        assert min(counts.values()) > expected * 0.9
+        assert max(counts.values()) < expected * 1.1
+
     def test_unknown_distribution(self):
-        with pytest.raises(
-            ValueError, match="Unknown distribution 'rademacher'"
-        ):
-            ar.do("random.array", (2, 3), dist="rademacher", like="numpy")
+        with pytest.raises(ValueError, match="Unknown distribution 'cauchy'"):
+            ar.do("random.array", (2, 3), dist="cauchy", like="numpy")
 
     def test_numpy_generator_selects_backend(self):
         numpy = pytest.importorskip("numpy")
@@ -304,7 +331,7 @@ class TestRandomArray:
         y = getattr(rng, method)((3, 4), dtype=numpy.float32)
         assert x == pytest.approx(y)
 
-    @pytest.mark.parametrize("dist", ["normal", "uniform"])
+    @pytest.mark.parametrize("dist", ["normal", "uniform", "rademacher"])
     @pytest.mark.parametrize(
         "backend,dtype,fn",
         gen_params(

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -2,7 +2,7 @@ import pytest
 
 import autoray as ar
 
-from .conftest import gen_params
+from .conftest import gen_params, gen_rand
 
 _RANDOM_BACKENDS = [
     "cupy",
@@ -159,3 +159,318 @@ def test_jax_jit_random():
     assert ar.do("allclose", x1, x2)
     x3 = ar.do("to_numpy", f(ar.do("array", 43)))
     assert not ar.do("allclose", x1, x3)
+
+
+class TestRandomArray:
+    @pytest.mark.parametrize("device", ["inherited", "cpu", "cuda"])
+    @pytest.mark.parametrize("dist", ["normal", "uniform"])
+    @pytest.mark.parametrize(
+        "backend,dtype,fn",
+        gen_params(
+            backends=_RANDOM_BACKENDS,
+            dtypes=...,
+            fns=["random.array"],
+        ),
+    )
+    def test_backend_dtype_device(self, backend, dtype, fn, dist, device):
+        if device == "cuda":
+            if backend == "torch":
+                import torch
+
+                if not torch.cuda.is_available():
+                    pytest.skip("CUDA is not available")
+            elif backend != "cupy":
+                pytest.skip(f"{backend} CUDA is not tested")
+        elif (device == "cpu") and backend in ("cupy", "dask", "mlx"):
+            pytest.skip(f"{backend} does not report a cpu device")
+
+        like = gen_rand((), backend, dtype)
+        _, like_device, _ = ar.infer_backend_device_dtype(like)
+        kwargs = {} if device == "inherited" else {"device": device}
+
+        x, y = (
+            ar.do(fn, (3, 4), dist=dist, rng=42, like=like, **kwargs)
+            for _ in range(2)
+        )
+
+        assert ar.do("shape", x) == (3, 4)
+        assert ar.get_dtype_name(x) == dtype
+        assert ar.do("allclose", x, y)
+        _, actual_device, _ = ar.infer_backend_device_dtype(x)
+
+        if device == "inherited":
+            assert actual_device == like_device
+        elif backend == "torch":
+            assert actual_device.type == device
+        elif backend == "jax":
+            assert actual_device.platform == device
+        elif backend == "tensorflow":
+            # a full device string like '/job:localhost/.../device:CPU:0'
+            assert actual_device.lower().endswith(f"{device}:0")
+        elif backend == "cupy":
+            assert actual_device == like_device
+        else:
+            assert actual_device == device
+
+        if "complex" in dtype:
+            assert ar.do("std", ar.real(x)) > 0.0
+            assert ar.do("std", ar.imag(x)) > 0.0
+
+    @pytest.mark.parametrize(
+        "backend,dtype,fn",
+        gen_params(
+            backends=_RANDOM_BACKENDS,
+            dtypes=["complex64", "complex128"],
+            fns=["random.array"],
+        ),
+    )
+    def test_complex_normal_has_unit_total_variance(self, backend, dtype, fn):
+        x = ar.do(
+            fn,
+            (100_000,),
+            dist="normal",
+            dtype=dtype,
+            rng=42,
+            like=backend,
+        )
+        assert ar.get_dtype_name(x) == dtype
+        x = ar.do("to_numpy", x)
+        assert (abs(x) ** 2).mean() == pytest.approx(1.0, abs=0.03)
+
+    @pytest.mark.parametrize("dist", ["normal", "uniform"])
+    @pytest.mark.parametrize(
+        "backend,fn",
+        gen_params(
+            backends=_RANDOM_BACKENDS,
+            fns=["random.array"],
+        ),
+    )
+    def test_loc_scale(self, backend, fn, dist):
+        x = ar.do(
+            fn,
+            (3, 4),
+            dist=dist,
+            dtype="float32",
+            rng=42,
+            like=backend,
+        )
+        y = ar.do(
+            fn,
+            (3, 4),
+            dist=dist,
+            loc=2.0,
+            scale=3.0,
+            dtype="float32",
+            rng=42,
+            like=backend,
+        )
+        assert ar.do("to_numpy", y) == pytest.approx(
+            2.0 + 3.0 * ar.do("to_numpy", x)
+        )
+
+    def test_unknown_distribution(self):
+        with pytest.raises(
+            ValueError, match="Unknown distribution 'rademacher'"
+        ):
+            ar.do("random.array", (2, 3), dist="rademacher", like="numpy")
+
+    def test_numpy_generator_selects_backend(self):
+        numpy = pytest.importorskip("numpy")
+        rng = numpy.random.default_rng(42)
+        x = ar.do("random.array", (2, 3), rng=rng)
+        assert isinstance(x, numpy.ndarray)
+        assert x.dtype == numpy.float64
+
+        x = ar.do("random.array", (2, 3), dtype="complex64")
+        assert isinstance(x, numpy.ndarray)
+        assert x.dtype == numpy.complex64
+
+    @pytest.mark.parametrize(
+        "dist,method",
+        [("normal", "standard_normal"), ("uniform", "random")],
+    )
+    def test_numpy_uses_dtype_aware_primitive(self, dist, method):
+        numpy = pytest.importorskip("numpy")
+        rng = numpy.random.default_rng(42)
+        x = ar.do(
+            "random.array",
+            (3, 4),
+            dist=dist,
+            dtype="float32",
+            rng=rng,
+        )
+
+        rng = numpy.random.default_rng(42)
+        y = getattr(rng, method)((3, 4), dtype=numpy.float32)
+        assert x == pytest.approx(y)
+
+    @pytest.mark.parametrize("dist", ["normal", "uniform"])
+    @pytest.mark.parametrize(
+        "backend,dtype,fn",
+        gen_params(
+            backends=_RANDOM_BACKENDS,
+            dtypes=...,
+            fns=["random.array"],
+            requires="random.seed",
+        ),
+    )
+    def test_none_uses_global_rng(self, backend, dtype, fn, dist):
+        ar.do("random.seed", 42, like=backend)
+        x = ar.do(fn, (3, 4), dist=dist, dtype=dtype, like=backend)
+        ar.do("random.seed", 42, like=backend)
+        y = ar.do(fn, (3, 4), dist=dist, dtype=dtype, like=backend)
+        assert ar.get_dtype_name(x) == dtype
+        assert ar.do("allclose", x, y)
+        if "complex" in dtype:
+            assert ar.do("std", ar.real(x)) > 0.0
+            assert ar.do("std", ar.imag(x)) > 0.0
+
+    def test_namespace_inherits_dtype(self):
+        numpy = pytest.importorskip("numpy")
+        xp = ar.get_namespace(numpy.empty((), dtype=numpy.float32))
+        x = xp.random.array((2, 3), rng=42)
+        assert x.dtype == numpy.float32
+
+    def test_jax_key_selects_backend(self):
+        jax = pytest.importorskip("jax")
+        key = jax.random.key(42)
+        x = ar.do("random.array", (2, 3), dtype="float32", rng=key)
+        assert ar.infer_backend(x) == "jax"
+
+    def test_torch_generator_selects_backend(self):
+        torch = pytest.importorskip("torch")
+        rng = torch.Generator().manual_seed(42)
+        x = ar.do("random.array", (2, 3), dtype="float32", rng=rng)
+        assert ar.infer_backend(x) == "torch"
+
+    def test_jax_seedless_default_rng_warns(self):
+        pytest.importorskip("jax")
+        # the warning is emitted one time only, so reset it first
+        ar.autoray._warn_jax_generated_seed.cache_clear()
+        with pytest.warns(RuntimeWarning, match="reuses the same seed"):
+            ar.do("random.default_rng", None, like="jax")
+
+    def test_jax_jit_none_rng_is_frozen(self):
+        jax = pytest.importorskip("jax")
+
+        @jax.jit
+        def f():
+            return ar.do(
+                "random.array",
+                (2, 3),
+                dtype="float32",
+                rng=None,
+                like="jax",
+            )
+
+        try:
+            x1 = f()
+            x2 = f()
+            assert ar.do("allclose", x1, x2)
+
+            # tracing leaves a tracer in the shared generator, so this fails
+            with pytest.raises(jax.errors.UnexpectedTracerError):
+                ar.do("random.array", (2, 3), dtype="float32", like="jax")
+        finally:
+            ar.do("random.seed", 42, like="jax")
+
+    def test_jax_jit_captured_generator_is_frozen(self):
+        jax = pytest.importorskip("jax")
+        rng = ar.do("random.default_rng", 42, like="jax")
+
+        @jax.jit
+        def f():
+            return ar.do("random.array", (2, 3), dtype="float32", rng=rng)
+
+        # each call hits the trace cache, so no error, just the same values
+        x1 = f()
+        x2 = f()
+        assert ar.do("allclose", x1, x2)
+
+        # tracing leaves a tracer in the captured generator
+        with pytest.raises(jax.errors.UnexpectedTracerError):
+            rng.normal(size=(2, 3))
+
+    def test_jax_jit(self):
+        jax = pytest.importorskip("jax")
+        jnp = pytest.importorskip("jax.numpy")
+
+        @jax.jit
+        def f(seed, loc, scale):
+            rng = ar.do("random.default_rng", seed, like="jax")
+            return (
+                ar.do(
+                    "random.array",
+                    (3, 4),
+                    loc=loc,
+                    scale=scale,
+                    dtype="float32",
+                    rng=rng,
+                    like="jax",
+                ),
+                ar.do(
+                    "random.array",
+                    (3, 4),
+                    loc=loc,
+                    scale=scale,
+                    dtype="float32",
+                    rng=rng,
+                    like="jax",
+                ),
+            )
+
+        x1, y1 = f(jnp.asarray(42), jnp.asarray(2.0), jnp.asarray(3.0))
+        x2, y2 = f(jnp.asarray(42), jnp.asarray(2.0), jnp.asarray(3.0))
+        x3, _ = f(jnp.asarray(43), jnp.asarray(2.0), jnp.asarray(3.0))
+        assert ar.do("allclose", x1, x2)
+        assert ar.do("allclose", y1, y2)
+        assert not ar.do("allclose", x1, y1)
+        assert not ar.do("allclose", x1, x3)
+
+    def test_torch_compile(self):
+        torch = pytest.importorskip("torch")
+        if not hasattr(torch, "compile"):
+            pytest.skip("torch.compile is unavailable")
+
+        # warm autoray's function cache, dynamo cannot trace the lazy import
+        ar.do("random.array", (1,), dtype="float32", rng=None, like="torch")
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f():
+            return ar.do(
+                "random.array",
+                (3, 4),
+                dtype="float32",
+                rng=None,
+                like="torch",
+            )
+
+        x = f()
+        y = f()
+        assert not torch.allclose(x, y)
+
+    def test_torch_none_uses_global_rng(self):
+        torch = pytest.importorskip("torch")
+        torch.manual_seed(42)
+        x = ar.do("random.array", (3, 4), dtype="float32", like="torch")
+        torch.manual_seed(42)
+        y = ar.do("random.array", (3, 4), dtype="float32", like="torch")
+        assert x.dtype == torch.float32
+        assert torch.allclose(x, y)
+
+    def test_mlx_global_rng_is_the_native_one(self):
+        mx = pytest.importorskip("mlx.core")
+
+        # mlx's own seed reaches autoray
+        mx.random.seed(42)
+        x = ar.do("random.array", (3, 4), dtype="float32", like="mlx")
+        mx.random.seed(42)
+        y = ar.do("random.array", (3, 4), dtype="float32", like="mlx")
+        assert ar.do("allclose", x, y)
+
+        # and autoray's seed reaches mlx
+        ar.do("random.seed", 42, like="mlx")
+        a = mx.random.normal((3, 4))
+        ar.do("random.seed", 42, like="mlx")
+        b = mx.random.normal((3, 4))
+        assert ar.do("allclose", a, b)


### PR DESCRIPTION
This adds a unified way to get backend agnostic random numbers with the following properties:

- `dtype` and `device` are picked up from `like` or can be specified
- `dist` is just a parameter to supply (currently allows "normal" or "uniform")
- complex dtype handled uniformly (e.g. complex normal has E[|z|^2] = 1)
- implicit global state and explicit local state both handled by `rng` kwarg
- `loc` and `scale` handled uniformly

This will be the recommended way to generate random numbers with autoray for most use cases.